### PR TITLE
Disable cache on submit

### DIFF
--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -713,11 +713,15 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
 
     public function renderWidget($hookName = null, array $configuration = [])
     {
-        if (!$this->isCached('ps_emailsubscription.tpl', $this->getCacheId()) && !$this->error && !$this->valid) {
+        $cacheId = $this->getCacheId();
+        if (Tools::isSubmit('submitNewsletter') || !$this->isCached('ps_emailsubscription.tpl', $cacheId)) {
             $this->smarty->assign($this->getWidgetVariables($hookName, $configuration));
         }
+        if (Tools::isSubmit('submitNewsletter')) {
+            $cacheId = null;
+        }
 
-        return $this->display(__FILE__, 'ps_emailsubscription.tpl', $this->getCacheId());
+        return $this->display(__FILE__, 'ps_emailsubscription.tpl', $cacheId);
     }
 
     public function getWidgetVariables($hookName = null, array $configuration = [])

--- a/views/templates/hook/ps_emailsubscription.tpl
+++ b/views/templates/hook/ps_emailsubscription.tpl
@@ -33,7 +33,7 @@
     {if isset($need_confirmation) && $need_confirmation}
     <span class="custom-checkbox">
        <input type="checkbox" name="confirm-optin" value="1" required>
-       <label>{l s='I agree to receive newsletter emails and I am aware of [1]the privacy policy[/1]' tags=['<a href="%s">'|sprintf:$cms_privacy_link] mod='ps_emailsubscription'}</label>
+       <label>{l s='I agree to receive newsletter emails and I am aware of [1]the privacy policy[/1]' tags=['<a target="_blank" href="%s">'|sprintf:$cms_privacy_link] mod='ps_emailsubscription'}</label>
     </span>
     {/if}
     <input type="submit" value="ok" name="submitNewsletter" />


### PR DESCRIPTION
When we submit the form for the newsletter subscription, we should not use the cache.
This PR fixes the missing result messages when submitting the form.

At the same time, we add the `target="_blank"` in order to display the pricacy policy in a new page.