### PR TITLE
Module must return an array of FormField instances

### DIFF
--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -791,10 +791,11 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             'Modules.EmailSubscription.Shop'
         );
 
-        return (new FormField())
+        return array(
+            (new FormField())
                 ->setName('newsletter')
                 ->setType('checkbox')
-                ->setLabel($label);
+                ->setLabel($label));
     }
 
     public function renderForm()


### PR DESCRIPTION
Once the PR PrestaShop/PrestaShop#6374 merged, this module won't work.

This PR must be merged in order to make this module working again.