### PR TITLE
Fix english wording

### DIFF
--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -106,8 +106,8 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                     'value_default' => 2,
                 ),
                 'OPTIN' => array(
-                    'title' => $this->trans('Opted-in subscribers', array(), 'Modules.EmailSubscription.Admin'),
-                    'desc' => $this->trans('Filter opted-in subscribers.', array(), 'Modules.EmailSubscription.Admin'),
+                    'title' => $this->trans('Opt-in subscribers', array(), 'Modules.EmailSubscription.Admin'),
+                    'desc' => $this->trans('Filter opt-in subscribers.', array(), 'Modules.EmailSubscription.Admin'),
                     'type' => 'select',
                     'value' => array(
                         0 => $this->trans('All customers', array(), 'Modules.EmailSubscription.Admin'),


### PR DESCRIPTION
Once again corrected to proper English like last it was done last November in former blocknewsletter.php: https://github.com/PrestaShop/blocknewsletter/commit/bed58cdbf656b2e9734daad37ebf22d0ba7992b4
And why did you change this distinct module name "newsletter" to an unclear "ps_emailsubscription"? Do you really think someone would confuse the former unique name with documents sent by post? I mean, welcome in the 21. century. :)