### PR TITLE
Add frontoffice subscription controller

### DIFF
--- a/controllers/front/subscription.php
+++ b/controllers/front/subscription.php
@@ -1,0 +1,67 @@
+<?php
+/*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+/**
+ * @since 1.5.0
+ */
+class Ps_EmailsubscriptionSubscriptionModuleFrontController extends ModuleFrontController
+{
+    private $variables = [];
+
+    /**
+     * @see FrontController::postProcess()
+     */
+    public function postProcess()
+    {
+
+        $this->variables['value'] = Tools::getValue('email', '');
+        $this->variables['msg'] = '';
+        $this->variables['conditions'] = Configuration::get('NW_CONDITIONS', $this->context->language->id);
+
+        if (Tools::isSubmit('submitNewsletter')) {
+            $this->module->newsletterRegistration();
+            if ($this->module->error) {
+                $this->variables['msg'] = $this->module->error;
+                $this->variables['nw_error'] = true;
+            } elseif ($this->module->valid) {
+                $this->variables['msg'] = $this->module->valid;
+                $this->variables['nw_error'] = false;
+            }
+        }
+
+    }
+
+    /**
+     * @see FrontController::initContent()
+     */
+    public function initContent()
+    {
+        parent::initContent();
+
+        $this->context->smarty->assign('variables', $this->variables);
+        $this->setTemplate('module:ps_emailsubscription/views/templates/front/subscription_execution.tpl');
+    }
+}

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -45,7 +45,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $this->name = 'ps_emailsubscription';
         $this->need_instance = 0;
 
-        $this->controllers = array('verification');
+        $this->controllers = array('verification', 'subscription');
 
         $this->bootstrap = true;
         parent::__construct();
@@ -329,7 +329,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     /**
      * Register in email subscription.
      */
-    protected function newsletterRegistration()
+    public function newsletterRegistration()
     {
         if (empty($_POST['email']) || !Validate::isEmail($_POST['email'])) {
             return $this->error = $this->trans('Invalid email address.', array(), 'Shop.Notifications.Error');

--- a/views/templates/front/subscription_execution.tpl
+++ b/views/templates/front/subscription_execution.tpl
@@ -1,0 +1,40 @@
+{*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+
+{extends file='page.tpl'}
+
+{block name="page_content"}
+  <h1>{l s='Newsletter subscription' mod='Modules.Emailsubscription.Shop'}</h1>
+
+  <p class="alert {if $variables.nw_error}alert-danger{else}alert-success{/if}">
+    {$variables.msg}
+  </p>
+
+  {if $variables.conditions}
+    <p>{$variables.conditions}</p>
+  {/if}
+
+{/block}
+


### PR DESCRIPTION
Needed subscriptions form in diffrent place than module itself. Example: I would like to use popup module with newsletter subscription form, and it is not possible when newsletter module is unhooked becouse subscription was handled inside newsletter module rendner widget function. Forge ticket: http://forge.prestashop.com/browse/BOOM-2499