### PR TITLE
fix for ps_emailsubscription not sending voucher email

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "prestashop/ps_emailsubscription",
   "description": "PrestaShop module ps_emailsubscription",
   "homepage": "https://github.com/PrestaShop/ps_emailsubscription",
-  "license": "AFL - Academic Free License (AFL 3.0)",
+  "license": "AFL-3.0",
   "authors": [
     {
       "name": "PrestaShop SA",

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_emailsubscription</name>
     <displayName><![CDATA[E-mail subscription form]]></displayName>
-    <version><![CDATA[2.3.0]]></version>
+    <version><![CDATA[2.3.1]]></version>
     <description><![CDATA[Adds a block for newsletter subscription.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <confirmUninstall><![CDATA[Are you sure that you want to delete all of your contacts?]]></confirmUninstall>

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_emailsubscription</name>
     <displayName><![CDATA[E-mail subscription form]]></displayName>
-    <version><![CDATA[2.2.0]]></version>
+    <version><![CDATA[2.3.0]]></version>
     <description><![CDATA[Adds a block for newsletter subscription.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <confirmUninstall><![CDATA[Are you sure that you want to delete all of your contacts?]]></confirmUninstall>

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_emailsubscription</name>
     <displayName><![CDATA[E-mail subscription form]]></displayName>
-    <version><![CDATA[2.0.0]]></version>
+    <version><![CDATA[2.1.0]]></version>
     <description><![CDATA[Adds a block for newsletter subscription.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <confirmUninstall><![CDATA[Are you sure that you want to delete all of your contacts?]]></confirmUninstall>

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_emailsubscription</name>
     <displayName><![CDATA[E-mail subscription form]]></displayName>
-    <version><![CDATA[2.1.0]]></version>
+    <version><![CDATA[2.2.0]]></version>
     <description><![CDATA[Adds a block for newsletter subscription.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <confirmUninstall><![CDATA[Are you sure that you want to delete all of your contacts?]]></confirmUninstall>

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_emailsubscription</name>
     <displayName><![CDATA[E-mail subscription form]]></displayName>
-    <version><![CDATA[1.1.6]]></version>
+    <version><![CDATA[2.0.0]]></version>
     <description><![CDATA[Adds a block for newsletter subscription.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <confirmUninstall><![CDATA[Are you sure that you want to delete all of your contacts?]]></confirmUninstall>

--- a/controllers/front/subscription.php
+++ b/controllers/front/subscription.php
@@ -1,0 +1,67 @@
+<?php
+/*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+/**
+ * @since 1.5.0
+ */
+class Ps_EmailsubscriptionSubscriptionModuleFrontController extends ModuleFrontController
+{
+    private $variables = [];
+
+    /**
+     * @see FrontController::postProcess()
+     */
+    public function postProcess()
+    {
+
+        $this->variables['value'] = Tools::getValue('email', '');
+        $this->variables['msg'] = '';
+        $this->variables['conditions'] = Configuration::get('NW_CONDITIONS', $this->context->language->id);
+
+        if (Tools::isSubmit('submitNewsletter')) {
+            $this->module->newsletterRegistration();
+            if ($this->module->error) {
+                $this->variables['msg'] = $this->module->error;
+                $this->variables['nw_error'] = true;
+            } elseif ($this->module->valid) {
+                $this->variables['msg'] = $this->module->valid;
+                $this->variables['nw_error'] = false;
+            }
+        }
+
+    }
+
+    /**
+     * @see FrontController::initContent()
+     */
+    public function initContent()
+    {
+        parent::initContent();
+
+        $this->context->smarty->assign('variables', $this->variables);
+        $this->setTemplate('module:ps_emailsubscription/views/templates/front/subscription_execution.tpl');
+    }
+}

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -57,7 +57,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
 
         $this->entity_manager = $entity_manager;
 
-        $this->version = '2.0.0';
+        $this->version = '2.1.0';
         $this->author = 'PrestaShop';
         $this->error = false;
         $this->valid = false;

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -50,10 +50,10 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $this->bootstrap = true;
         parent::__construct();
 
-        $this->displayName = $this->trans('Newsletter subscription', array(), 'Modules.EmailSubscription.Admin');
-        $this->description = $this->trans('Adds a form for newsletter subscription.', array(), 'Modules.EmailSubscription.Admin');
-        $this->confirmUninstall = $this->trans('Are you sure that you want to delete all of your contacts?', array(), 'Modules.EmailSubscription.Admin');
-        $this->ps_versions_compliancy = array('min' => '1.7.0.0', 'max' => _PS_VERSION_);
+        $this->displayName = $this->trans('Newsletter subscription', array(), 'Modules.Emailsubscription.Admin');
+        $this->description = $this->trans('Adds a form for newsletter subscription.', array(), 'Modules.Emailsubscription.Admin');
+        $this->confirmUninstall = $this->trans('Are you sure that you want to delete all of your contacts?', array(), 'Modules.Emailsubscription.Admin');
+        $this->ps_versions_compliancy = array('min' => '1.7.1.0', 'max' => _PS_VERSION_);
 
         $this->entity_manager = $entity_manager;
 
@@ -213,13 +213,13 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                 'search' => false,
             ),
             'subscribed' => array(
-                'title' => $this->trans('Subscribed', array(), 'Modules.EmailSubscription.Admin'),
+                'title' => $this->trans('Subscribed', array(), 'Modules.Emailsubscription.Admin'),
                 'type' => 'bool',
                 'active' => 'subscribed',
                 'search' => false,
             ),
             'newsletter_date_add' => array(
-                'title' => $this->trans('Subscribed on', array(), 'Modules.EmailSubscription.Admin'),
+                'title' => $this->trans('Subscribed on', array(), 'Modules.Emailsubscription.Admin'),
                 'type' => 'date',
                 'search' => false,
             ),
@@ -231,7 +231,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
 
         $helper_list = new HelperList();
         $helper_list->module = $this;
-        $helper_list->title = $this->trans('Newsletter registrations', array(), 'Modules.EmailSubscription.Admin');
+        $helper_list->title = $this->trans('Newsletter registrations', array(), 'Modules.Emailsubscription.Admin');
         $helper_list->shopLinkType = '';
         $helper_list->no_link = true;
         $helper_list->show_toolbar = true;
@@ -283,7 +283,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     {
         $this->smarty->assign(array(
             'href' => $this->_helperlist->currentIndex.'&subscribedcustomer&'.$this->_helperlist->identifier.'='.$id.'&token='.$token,
-            'action' => $this->trans('Unsubscribe', array(), 'Modules.EmailSubscription.Admin'),
+            'action' => $this->trans('Unsubscribe', array(), 'Modules.Emailsubscription.Admin'),
         ));
 
         return $this->display(__FILE__, 'views/templates/admin/list_action_unsubscribe.tpl');
@@ -337,18 +337,18 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             $register_status = $this->isNewsletterRegistered($_POST['email']);
 
             if ($register_status < 1) {
-                return $this->error = $this->trans('This email address is not registered.', array(), 'Modules.EmailSubscription.Shop');
+                return $this->error = $this->trans('This email address is not registered.', array(), 'Modules.Emailsubscription.Shop');
             }
 
             if (!$this->unregister($_POST['email'], $register_status)) {
-                return $this->error = $this->trans('An error occurred while attempting to unsubscribe.', array(), 'Modules.EmailSubscription.Shop');
+                return $this->error = $this->trans('An error occurred while attempting to unsubscribe.', array(), 'Modules.Emailsubscription.Shop');
             }
 
-            return $this->valid = $this->trans('Unsubscription successful.', array(), 'Modules.EmailSubscription.Shop');
+            return $this->valid = $this->trans('Unsubscription successful.', array(), 'Modules.Emailsubscription.Shop');
         } elseif ($_POST['action'] == '0') {
             $register_status = $this->isNewsletterRegistered($_POST['email']);
             if ($register_status > 0) {
-                return $this->error = $this->trans('This email address is already registered.', array(), 'Modules.EmailSubscription.Shop');
+                return $this->error = $this->trans('This email address is already registered.', array(), 'Modules.Emailsubscription.Shop');
             }
 
             $email = pSQL($_POST['email']);
@@ -360,17 +360,17 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                     }
 
                     if (!$token = $this->getToken($email, $register_status)) {
-                        return $this->error = $this->trans('An error occurred during the subscription process.', array(), 'Modules.EmailSubscription.Shop');
+                        return $this->error = $this->trans('An error occurred during the subscription process.', array(), 'Modules.Emailsubscription.Shop');
                     }
 
                     $this->sendVerificationEmail($email, $token);
 
-                    return $this->valid = $this->trans('A verification email has been sent. Please check your inbox.', array(), 'Modules.EmailSubscription.Shop');
+                    return $this->valid = $this->trans('A verification email has been sent. Please check your inbox.', array(), 'Modules.Emailsubscription.Shop');
                 } else {
                     if ($this->register($email, $register_status)) {
-                        $this->valid = $this->trans('You have successfully subscribed to this newsletter.', array(), 'Modules.EmailSubscription.Shop');
+                        $this->valid = $this->trans('You have successfully subscribed to this newsletter.', array(), 'Modules.Emailsubscription.Shop');
                     } else {
-                        return $this->error = $this->trans('An error occurred during the subscription process.', array(), 'Modules.EmailSubscription.Shop');
+                        return $this->error = $this->trans('An error occurred during the subscription process.', array(), 'Modules.Emailsubscription.Shop');
                     }
 
                     if ($code = Configuration::get('NW_VOUCHER_CODE')) {
@@ -605,7 +605,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         }
 
         if (!$activated) {
-            return $this->trans('This email is already registered and/or invalid.', array(), 'Modules.EmailSubscription.Shop');
+            return $this->trans('This email is already registered and/or invalid.', array(), 'Modules.Emailsubscription.Shop');
         }
 
         if ($discount = Configuration::get('NW_VOUCHER_CODE')) {
@@ -616,7 +616,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             $this->sendConfirmationEmail($email);
         }
 
-        return $this->trans('Thank you for subscribing to our newsletter.', array(), 'Modules.EmailSubscription.Shop');
+        return $this->trans('Thank you for subscribing to our newsletter.', array(), 'Modules.Emailsubscription.Shop');
     }
 
     /**
@@ -813,7 +813,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                 '%conditions%' => Configuration::get('NW_CONDITIONS', $this->context->language->id),
                 '[/2]' => '</em>',
             ),
-            'Modules.EmailSubscription.Shop'
+            'Modules.Emailsubscription.Shop'
         );
 
         return array(
@@ -834,7 +834,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                 'input' => array(
                     array(
                         'type' => 'switch',
-                        'label' => $this->trans('Would you like to send a verification email after subscription?', array(), 'Modules.EmailSubscription.Admin'),
+                        'label' => $this->trans('Would you like to send a verification email after subscription?', array(), 'Modules.Emailsubscription.Admin'),
                         'name' => 'NW_VERIFICATION_EMAIL',
                         'values' => array(
                             array(
@@ -851,7 +851,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                     ),
                     array(
                         'type' => 'switch',
-                        'label' => $this->trans('Would you like to send a confirmation email after subscription?', array(), 'Modules.EmailSubscription.Admin'),
+                        'label' => $this->trans('Would you like to send a confirmation email after subscription?', array(), 'Modules.Emailsubscription.Admin'),
                         'name' => 'NW_CONFIRMATION_EMAIL',
                         'values' => array(
                             array(
@@ -868,14 +868,14 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                     ),
                     array(
                         'type' => 'text',
-                        'label' => $this->trans('Welcome voucher code', array(), 'Modules.EmailSubscription.Admin'),
+                        'label' => $this->trans('Welcome voucher code', array(), 'Modules.Emailsubscription.Admin'),
                         'name' => 'NW_VOUCHER_CODE',
                         'class' => 'fixed-width-md',
-                        'desc' => $this->trans('Leave blank to disable by default.', array(), 'Modules.EmailSubscription.Admin'),
+                        'desc' => $this->trans('Leave blank to disable by default.', array(), 'Modules.Emailsubscription.Admin'),
                     ),
                     array(
                         'type' => 'textarea',
-                        'label' => $this->trans('Newsletter conditions', array(), 'Modules.EmailSubscription.Admin'),
+                        'label' => $this->trans('Newsletter conditions', array(), 'Modules.Emailsubscription.Admin'),
                         'lang' => true,
                         'name' => 'NW_CONDITIONS',
                         'cols' => 40,
@@ -883,9 +883,9 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                         'hint' => $this->trans(
                             'This text will be displayed beneath the newsletter subscribe button.',
                             array(),
-                            'Modules.EmailSubscription.Admin'
+                            'Modules.Emailsubscription.Admin'
                         ),
-                        'desc' => $this->trans('Leave blank to disable by default.', array(), 'Modules.EmailSubscription.Admin'),
+                        'desc' => $this->trans('Leave blank to disable by default.', array(), 'Modules.Emailsubscription.Admin'),
                     ),
                 ),
                 'submit' => array(
@@ -927,14 +927,14 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $fields_form = array(
             'form' => array(
                 'legend' => array(
-                    'title' => $this->trans('Export customers\' addresses', array(), 'Modules.EmailSubscription.Admin'),
+                    'title' => $this->trans('Export customers\' addresses', array(), 'Modules.Emailsubscription.Admin'),
                     'icon' => 'icon-envelope',
                 ),
                 'input' => array(
                     array(
                         'type' => 'select',
-                        'label' => $this->trans('Customers\' country', array(), 'Modules.EmailSubscription.Admin'),
-                        'desc' => $this->trans('Filter customers by country.', array(), 'Modules.EmailSubscription.Admin'),
+                        'label' => $this->trans('Customers\' country', array(), 'Modules.Emailsubscription.Admin'),
+                        'desc' => $this->trans('Filter customers by country.', array(), 'Modules.Emailsubscription.Admin'),
                         'name' => 'COUNTRY',
                         'required' => false,
                         'default_value' => (int) $this->context->country->id,
@@ -946,18 +946,18 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                     ),
                     array(
                         'type' => 'select',
-                        'label' => $this->trans('Newsletter subscribers', array(), 'Modules.EmailSubscription.Admin'),
-                        'desc' => $this->trans('Filter customers who have subscribed to the newsletter or not, and who have an account or not.', array(), 'Modules.EmailSubscription.Admin'),
-                        'hint' => $this->trans('Customers can subscribe to your newsletter when registering, or by entering their email in the newsletter form.', array(), 'Modules.EmailSubscription.Admin'),
+                        'label' => $this->trans('Newsletter subscribers', array(), 'Modules.Emailsubscription.Admin'),
+                        'desc' => $this->trans('Filter customers who have subscribed to the newsletter or not, and who have an account or not.', array(), 'Modules.Emailsubscription.Admin'),
+                        'hint' => $this->trans('Customers can subscribe to your newsletter when registering, or by entering their email in the newsletter form.', array(), 'Modules.Emailsubscription.Admin'),
                         'name' => 'SUSCRIBERS',
                         'required' => false,
                         'default_value' => (int) $this->context->country->id,
                         'options' => array(
                             'query' => array(
-                                array('id' => 0, 'name' => $this->trans('All subscribers', array(), 'Modules.EmailSubscription.Admin')),
-                                array('id' => 1, 'name' => $this->trans('Subscribers with account', array(), 'Modules.EmailSubscription.Admin')),
-                                array('id' => 2, 'name' => $this->trans('Subscribers without account', array(), 'Modules.EmailSubscription.Admin')),
-                                array('id' => 3, 'name' => $this->trans('Non-subscribers', array(), 'Modules.EmailSubscription.Admin')),
+                                array('id' => 0, 'name' => $this->trans('All subscribers', array(), 'Modules.Emailsubscription.Admin')),
+                                array('id' => 1, 'name' => $this->trans('Subscribers with account', array(), 'Modules.Emailsubscription.Admin')),
+                                array('id' => 2, 'name' => $this->trans('Subscribers without account', array(), 'Modules.Emailsubscription.Admin')),
+                                array('id' => 3, 'name' => $this->trans('Non-subscribers', array(), 'Modules.Emailsubscription.Admin')),
                             ),
                             'id' => 'id',
                             'name' => 'name',
@@ -965,17 +965,17 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                     ),
                     array(
                         'type' => 'select',
-                        'label' => $this->trans('Partner offers subscribers', array(), 'Modules.EmailSubscription.Admin'),
-                        'desc' => $this->trans('Filter customers who have agreed to receive your partners\' offers or not.', array(), 'Modules.EmailSubscription.Admin'),
-                        'hint' => $this->trans('Partner offers subscribers have agreed to receive your partners\' offers.', array(), 'Modules.EmailSubscription.Admin'),
+                        'label' => $this->trans('Partner offers subscribers', array(), 'Modules.Emailsubscription.Admin'),
+                        'desc' => $this->trans('Filter customers who have agreed to receive your partners\' offers or not.', array(), 'Modules.Emailsubscription.Admin'),
+                        'hint' => $this->trans('Partner offers subscribers have agreed to receive your partners\' offers.', array(), 'Modules.Emailsubscription.Admin'),
                         'name' => 'OPTIN',
                         'required' => false,
                         'default_value' => (int) $this->context->country->id,
                         'options' => array(
                             'query' => array(
-                                array('id' => 0, 'name' => $this->trans('All customers', array(), 'Modules.EmailSubscription.Admin')),
-                                array('id' => 2, 'name' => $this->trans('Partner offers subscribers', array(), 'Modules.EmailSubscription.Admin')),
-                                array('id' => 1, 'name' => $this->trans('Partner offers non-subscribers', array(), 'Modules.EmailSubscription.Admin')),
+                                array('id' => 0, 'name' => $this->trans('All customers', array(), 'Modules.Emailsubscription.Admin')),
+                                array('id' => 2, 'name' => $this->trans('Partner offers subscribers', array(), 'Modules.Emailsubscription.Admin')),
+                                array('id' => 1, 'name' => $this->trans('Partner offers non-subscribers', array(), 'Modules.Emailsubscription.Admin')),
                             ),
                             'id' => 'id',
                             'name' => 'name',
@@ -1019,16 +1019,16 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $fields_form = array(
             'form' => array(
                 'legend' => array(
-                    'title' => $this->trans('Search for addresses', array(), 'Modules.EmailSubscription.Admin'),
+                    'title' => $this->trans('Search for addresses', array(), 'Modules.Emailsubscription.Admin'),
                     'icon' => 'icon-search',
                 ),
                 'input' => array(
                     array(
                         'type' => 'text',
-                        'label' => $this->trans('Email address to search', array(), 'Modules.EmailSubscription.Admin'),
+                        'label' => $this->trans('Email address to search', array(), 'Modules.Emailsubscription.Admin'),
                         'name' => 'searched_email',
                         'class' => 'fixed-width-xxl',
-                        'desc' => $this->trans('Example: contact@prestashop.com or @prestashop.com', array(), 'Modules.EmailSubscription.Admin'),
+                        'desc' => $this->trans('Example: contact@prestashop.com or @prestashop.com', array(), 'Modules.Emailsubscription.Admin'),
                     ),
                 ),
                 'submit' => array(
@@ -1087,7 +1087,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
 
         if ($result) {
             if (!$nb = count($result)) {
-                $this->_html .= $this->displayError($this->trans('No customers found with these filters!', array(), 'Modules.EmailSubscription.Admin'));
+                $this->_html .= $this->displayError($this->trans('No customers found with these filters!', array(), 'Modules.Emailsubscription.Admin'));
             } elseif ($fd = @fopen(dirname(__FILE__).'/'.strval(preg_replace('#\.{2,}#', '.', Tools::getValue('action'))).'_'.$this->file, 'w')) {
                 $header = array('id', 'shop_name', 'gender', 'lastname', 'firstname', 'email', 'subscribed', 'subscribed_on');
                 $array_to_export = array_merge(array($header), $result);
@@ -1096,21 +1096,21 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                 }
                 fclose($fd);
                 $this->_html .= $this->displayConfirmation(
-                    sprintf($this->trans('The .CSV file has been successfully exported: %d customers found.', array(), 'Modules.EmailSubscription.Admin'), $nb).'<br />
+                    sprintf($this->trans('The .CSV file has been successfully exported: %d customers found.', array(), 'Modules.Emailsubscription.Admin'), $nb).'<br />
                 <a href="'.$this->context->shop->getBaseURI().'modules/ps_emailsubscription/'.Tools::safeOutput(strval(Tools::getValue('action'))).'_'.$this->file.'">
-                <b>'.$this->trans('Download the file', array(), 'Modules.EmailSubscription.Admin').' '.$this->file.'</b>
+                <b>'.$this->trans('Download the file', array(), 'Modules.Emailsubscription.Admin').' '.$this->file.'</b>
                 </a>
                 <br />
                 <ol style="margin-top: 10px;">
                     <li style="color: red;">'.
-                    $this->trans('WARNING: When opening this .csv file with Excel, choose UTF-8 encoding to avoid strange characters.', array(), 'Modules.EmailSubscription.Admin').
+                    $this->trans('WARNING: When opening this .csv file with Excel, choose UTF-8 encoding to avoid strange characters.', array(), 'Modules.Emailsubscription.Admin').
                     '</li>
                 </ol>');
             } else {
-                $this->_html .= $this->displayError($this->trans('Error: Write access limited', array(), 'Modules.EmailSubscription.Admin').' '.dirname(__FILE__).'/'.strval(Tools::getValue('action')).'_'.$this->file.' !');
+                $this->_html .= $this->displayError($this->trans('Error: Write access limited', array(), 'Modules.Emailsubscription.Admin').' '.dirname(__FILE__).'/'.strval(Tools::getValue('action')).'_'.$this->file.' !');
             }
         } else {
-            $this->_html .= $this->displayError($this->trans('No result found!', array(), 'Modules.EmailSubscription.Admin'));
+            $this->_html .= $this->displayError($this->trans('No result found!', array(), 'Modules.Emailsubscription.Admin'));
         }
     }
 
@@ -1123,7 +1123,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
 
         $fake_object = new stdClass();
         $fake_object->id = 0;
-        $fake_object->name = $this->trans('-- Select associated page --', array(), 'Modules.EmailSubscription.Admin');
+        $fake_object->name = $this->trans('-- Select associated page --', array(), 'Modules.Emailsubscription.Admin');
         $cms_pages[-1] = $fake_object;
         unset($fake_object);
 
@@ -1202,7 +1202,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $line = implode(';', $array);
         $line .= "\n";
         if (!fwrite($fd, $line, 4096)) {
-            $this->post_errors[] = $this->trans('Error: Write access limited', array(), 'Modules.EmailSubscription.Admin').' '.dirname(__FILE__).'/'.$this->file.' !';
+            $this->post_errors[] = $this->trans('Error: Write access limited', array(), 'Modules.Emailsubscription.Admin').' '.dirname(__FILE__).'/'.$this->file.' !';
         }
     }
 
@@ -1211,7 +1211,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $locale = $lang['locale'];
 
         return
-            $this->trans('You may unsubscribe at any moment. For that purpose, please find our contact info in the legal notice.', array(), 'Modules.EmailSubscription.Shop', $locale)
+            $this->trans('You may unsubscribe at any moment. For that purpose, please find our contact info in the legal notice.', array(), 'Modules.Emailsubscription.Shop', $locale)
         ;
     }
 }

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -1,6 +1,6 @@
 <?php
 /*
-* 2007-2016 PrestaShop
+* 2007-2017 PrestaShop
 *
 * NOTICE OF LICENSE
 *
@@ -19,7 +19,7 @@
 * needs please refer to http://www.prestashop.com for more information.
 *
 *  @author PrestaShop SA <contact@prestashop.com>
-*  @copyright  2007-2016 PrestaShop SA
+*  @copyright  2007-2017 PrestaShop SA
 *  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *  International Registered Trademark & Property of PrestaShop SA
 */
@@ -97,6 +97,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                     'displayFooterBefore',
                     'actionCustomerAccountAdd',
                     'additionalCustomerFormFields',
+                    'displayAdminCustomersForm',
                 )
             )
         ) {
@@ -1213,5 +1214,42 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         return
             $this->trans('You may unsubscribe at any moment. For that purpose, please find our contact info in the legal notice.', array(), 'Modules.Emailsubscription.Shop', $locale)
         ;
+    }
+
+    /**
+     * This hook allow you to add new fields in the admin customer form
+     * @return string
+     */
+    public function hookDisplayAdminCustomersForm()
+    {
+        $newsletter = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('SELECT `newsletter`
+            FROM ' . _DB_PREFIX_ . 'customer
+            WHERE `id_customer` = ' . (int)Tools::getValue('id_customer', 0));
+
+        $input = array(
+            'type' => 'switch',
+            'label' => $this->trans('Newsletter', array(), 'Admin.Orderscustomers.Feature'),
+            'name' => 'newsletter',
+            'required' => false,
+            'class' => 't',
+            'is_bool' => true,
+            'value' => $newsletter,
+            'values' => array(
+                array(
+                    'id' => 'newsletter_on',
+                    'value' => 1,
+                    'label' => $this->trans('Enabled', array(), 'Admin.Global'),
+                ),
+                array(
+                    'id' => 'newsletter_off',
+                    'value' => 0,
+                    'label' => $this->trans('Disabled', array(), 'Admin.Global'),
+                )
+            ),
+            'hint' => $this->trans('This customer will receive your newsletter via email.', array(), 'Admin.Orderscustomers.Help'),
+        );
+        $this->context->smarty->assign(array('input' => $input));
+
+        return $this->display(__FILE__, 'views/templates/admin/newsletter_subscribe.tpl');
     }
 }

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -57,7 +57,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
 
         $this->entity_manager = $entity_manager;
 
-        $this->version = '2.1.0';
+        $this->version = '2.2.0';
         $this->author = 'PrestaShop';
         $this->error = false;
         $this->valid = false;

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -45,7 +45,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $this->name = 'ps_emailsubscription';
         $this->need_instance = 0;
 
-        $this->controllers = array('verification');
+        $this->controllers = array('verification', 'subscription');
 
         $this->bootstrap = true;
         parent::__construct();
@@ -330,7 +330,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     /**
      * Register in email subscription.
      */
-    protected function newsletterRegistration()
+    public function newsletterRegistration()
     {
         if (empty($_POST['email']) || !Validate::isEmail($_POST['email'])) {
             return $this->error = $this->trans('Invalid email address.', array(), 'Shop.Notifications.Error');

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -57,7 +57,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
 
         $this->entity_manager = $entity_manager;
 
-        $this->version = '2.3.0';
+        $this->version = '2.3.1';
         $this->author = 'PrestaShop';
         $this->error = false;
         $this->valid = false;

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -57,7 +57,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
 
         $this->entity_manager = $entity_manager;
 
-        $this->version = '2.2.0';
+        $this->version = '2.3.0';
         $this->author = 'PrestaShop';
         $this->error = false;
         $this->valid = false;
@@ -98,6 +98,9 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                     'actionCustomerAccountAdd',
                     'additionalCustomerFormFields',
                     'displayAdminCustomersForm',
+                    'registerGDPRConsent',
+                    'actionDeleteGDPRCustomer',
+                    'actionExportGDPRData'
                 )
             )
         ) {
@@ -751,6 +754,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     public function renderWidget($hookName = null, array $configuration = [])
     {
         $this->smarty->assign($this->getWidgetVariables($hookName, $configuration));
+        $this->context->smarty->assign(array('id_module' => $this->id));
 
         return $this->fetch('module:ps_emailsubscription/views/templates/hook/ps_emailsubscription.tpl');
     }
@@ -1252,4 +1256,25 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
 
         return $this->display(__FILE__, 'views/templates/admin/newsletter_subscribe.tpl');
     }
+
+    public function hookActionDeleteGDPRCustomer($customer)
+    {
+        if (!empty($customer['email']) && Validate::isEmail($customer['email'])) {
+            $sql = "DELETE FROM "._DB_PREFIX_."emailsubscription WHERE email = '".pSQL($customer['email'])."'";
+            if (Db::getInstance()->execute($sql)) {
+                return json_encode(true);
+            }
+            return json_encode($this->l('Newsletter subscription: Unable to delete customer using email.'));
+        }
+    }
+    public function hookActionExportGDPRData($customer)
+    {
+        if (!Tools::isEmpty($customer['email']) && Validate::isEmail($customer['email'])) {
+            $sql = "SELECT * FROM "._DB_PREFIX_."emailsubscription WHERE email = '".pSQL($customer['email'])."'";
+            if ($res = Db::getInstance()->ExecuteS($sql)) {
+                return json_encode($res);
+            }
+            return json_encode($this->l('Newsletter subscription: Unable to export customer using email.'));
+       }
+   }
 }

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -1264,7 +1264,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             if (Db::getInstance()->execute($sql)) {
                 return json_encode(true);
             }
-            return json_encode($this->l('Newsletter subscription: Unable to delete customer using email.'));
+            return json_encode($this->trans('Newsletter subscription: no email to delete, this customer has not registered.', array(), 'Modules.Emailsubscription.Admin'));
         }
     }
     public function hookActionExportGDPRData($customer)
@@ -1274,7 +1274,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             if ($res = Db::getInstance()->ExecuteS($sql)) {
                 return json_encode($res);
             }
-            return json_encode($this->l('Newsletter subscription: Unable to export customer using email.'));
+            return json_encode($this->trans('Newsletter subscription: no email to export, this customer has not registered.', array(), 'Modules.Emailsubscription.Admin'));
        }
    }
 }

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -57,7 +57,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
 
         $this->entity_manager = $entity_manager;
 
-        $this->version = '1.1.6';
+        $this->version = '2.0.0';
         $this->author = 'PrestaShop';
         $this->error = false;
         $this->valid = false;

--- a/upgrade/upgrade-2-3-0.php
+++ b/upgrade/upgrade-2-3-0.php
@@ -1,5 +1,6 @@
-{*
-* 2007-2016 PrestaShop
+<?php
+/*
+* 2007-2018 PrestaShop
 *
 * NOTICE OF LICENSE
 *
@@ -18,23 +19,16 @@
 * needs please refer to http://www.prestashop.com for more information.
 *
 *  @author PrestaShop SA <contact@prestashop.com>
-*  @copyright  2007-2016 PrestaShop SA
+*  @copyright  2007-2015 PrestaShop SA
 *  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *  International Registered Trademark & Property of PrestaShop SA
-*}
-
-<div class="email_subscription">
-  <h4>{l s='Newsletter' d='Modules.Emailsubscription.Shop'}</h4>
-  {if $msg}
-    <p class="notification {if $nw_error}notification-error{else}notification-success{/if}">{$msg}</p>
-  {/if}
-  <form action="{$urls.pages.index}" method="post">
-    <input type="text" name="email" value="{$value}" placeholder="{l s='Your e-mail' d='Modules.Emailsubscription.Shop'}" />
-    {if $conditions}
-      <p>{$conditions}</p>
-    {/if}
-    <input type="submit" value="ok" name="submitNewsletter" />
-    {hook h='displayGDPRConsent' id_module=$id_module}
-    <input type="hidden" name="action" value="0" />
-  </form>
-</div>
+*/
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+function upgrade_module_2_3_0($object)
+{
+    return ($object->registerHook('registerGDPRConsent') &&
+        $object->registerHook('actionDeleteGDPRCustomer') &&
+        $object->registerHook('actionExportGDPRData'));
+}

--- a/views/templates/admin/newsletter_subscribe.tpl
+++ b/views/templates/admin/newsletter_subscribe.tpl
@@ -1,0 +1,60 @@
+{*
+* 2007-2017 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2017 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+{block name="input_row"}
+  <div class="form-group">
+    {block name="label"}
+      <label class="control-label col-lg-3{if isset($input.required) && $input.required} required{/if}">
+          <span class="label-tooltip" data-toggle="tooltip" data-html="true" title="{if isset($input.hint)}{$input.hint|escape:'html':'UTF-8'}{/if}">
+            {if isset($input.label)}
+              {$input.label}
+            {/if}
+          </span>
+      </label>
+    {/block}
+    {block name="field"}
+      <div class="col-lg-9">
+        {block name="input"}
+          <span class="switch prestashop-switch fixed-width-lg">
+            {foreach $input.values as $value}
+              <input type="radio" name="{$input.name}"{if $value.value == 1} id="{$input.name}_on" {else} id="{$input.name}_off"{/if} value="{$value.value}"
+                {if $input.value == $value.value} checked="checked"{/if}
+              >
+              {strip}
+                <label {if $value.value == 1} for="{$input.name}_on"{else} for="{$input.name}_off"{/if}>
+                  {if $value.value == 1}
+                    {l s='Yes' d='Admin.Global'}
+                  {else}
+                    {l s='No' d='Admin.Global'}
+                  {/if}
+                </label>
+              {/strip}
+            {/foreach}
+            <a class="slide-button btn"></a>
+          </span>
+        {/block}
+      </div>
+    {/block}
+  </div>
+{/block}

--- a/views/templates/front/subscription_execution.tpl
+++ b/views/templates/front/subscription_execution.tpl
@@ -1,0 +1,40 @@
+{*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+
+{extends file='page.tpl'}
+
+{block name="page_content"}
+  <h1>{l s='Newsletter subscription' mod='Modules.Emailsubscription.Shop'}</h1>
+
+  <p class="alert {if $variables.nw_error}alert-danger{else}alert-success{/if}">
+    {$variables.msg}
+  </p>
+
+  {if $variables.conditions}
+    <p>{$variables.conditions}</p>
+  {/if}
+
+{/block}
+

--- a/views/templates/front/subscription_execution.tpl
+++ b/views/templates/front/subscription_execution.tpl
@@ -26,7 +26,7 @@
 {extends file='page.tpl'}
 
 {block name="page_content"}
-  <h1>{l s='Newsletter subscription' mod='Modules.Emailsubscription.Shop'}</h1>
+  <h1>{l s='Newsletter subscription' d='Modules.Emailsubscription.Shop'}</h1>
 
   <p class="alert {if $variables.nw_error}alert-danger{else}alert-success{/if}">
     {$variables.msg}

--- a/views/templates/hook/index.php
+++ b/views/templates/hook/index.php
@@ -1,0 +1,35 @@
+<?php
+/*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+				    	
+header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
+header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
+						
+header("Cache-Control: no-store, no-cache, must-revalidate");
+header("Cache-Control: post-check=0, pre-check=0", false);
+header("Pragma: no-cache");
+						
+header("Location: ../");
+exit;

--- a/views/templates/hook/ps_emailsubscription.tpl
+++ b/views/templates/hook/ps_emailsubscription.tpl
@@ -24,12 +24,12 @@
 *}
 
 <div class="email_subscription">
-  <h4>{l s='Newsletter' d='Modules.EmailSubscription.Shop'}</h4>
+  <h4>{l s='Newsletter' d='Modules.Emailsubscription.Shop'}</h4>
   {if $msg}
     <p class="notification {if $nw_error}notification-error{else}notification-success{/if}">{$msg}</p>
   {/if}
   <form action="{$urls.pages.index}" method="post">
-    <input type="text" name="email" value="{$value}" placeholder="{l s='Your e-mail' d='Modules.EmailSubscription.Shop'}" />
+    <input type="text" name="email" value="{$value}" placeholder="{l s='Your e-mail' d='Modules.Emailsubscription.Shop'}" />
     {if $conditions}
       <p>{$conditions}</p>
     {/if}


### PR DESCRIPTION
I did modify the file ps_emailsubscription.php on function hookActionCustomerAccountAdd adding some lines to check voucher existance and send it to client if true.

`public function hookActionCustomerAccountAdd($params)
{
    //if e-mail of the created user address has already been added to the newsletter through the ps_emailsubscription module,
    //we delete it from ps_emailsubscription table to prevent duplicates
    $id_shop = $params['newCustomer']->id_shop;
    $email = $params['newCustomer']->email;
    if (Validate::isEmail($email)) {
//START MODIFICATION
//new line sending confirmation email
$this->sendConfirmationEmail($email);
//new IF checking if there is a discount to send to customer
if ($discount = Configuration::get('NW_VOUCHER_CODE')) {
$this->sendVoucher($email, $discount);
}
//END MODIFICATION
        return (bool) Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'emailsubscription WHERE id_shop='.(int) $id_shop.' AND email=\''.pSQL($email)."'");
    }

    return true;
}`