### PR TITLE
Fix compatibility of v2.5 with PS 1.7.6 and 1.7.5

### DIFF
--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -48,6 +48,9 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     const TPL_COLUMN = 'ps_emailsubscription-column.tpl';
     const TPL_DEFAULT = 'ps_emailsubscription.tpl';
 
+    /**
+     * @param EntityManager $entity_manager
+     */
     public function __construct(EntityManager $entity_manager)
     {
         $this->name = 'ps_emailsubscription';
@@ -81,7 +84,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
 
         $this->_html = '';
         if ($this->id) {
-            $this->file = 'export_'.Configuration::get('PS_NEWSLETTER_RAND').'.csv';
+            $this->file = 'export_' . Configuration::get('PS_NEWSLETTER_RAND') . '.csv';
             $this->post_valid = array();
 
             // Getting data...
@@ -107,7 +110,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                     'displayAdminCustomersForm',
                     'registerGDPRConsent',
                     'actionDeleteGDPRCustomer',
-                    'actionExportGDPRData'
+                    'actionExportGDPRData',
                 )
             )
         ) {
@@ -116,7 +119,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
 
         if ($this->uninstallPrestaShop16Module()) {
             // 1.6 Module exist and was uninstalled
-            Db::getInstance()->execute('RENAME TABLE `'._DB_PREFIX_.'newsletter` to `'._DB_PREFIX_.'emailsubscription`');
+            Db::getInstance()->execute('RENAME TABLE `' . _DB_PREFIX_ . 'newsletter` to `' . _DB_PREFIX_ . 'emailsubscription`');
         } else {
             Configuration::updateValue('PS_NEWSLETTER_RAND', mt_rand() . mt_rand());
             Configuration::updateValue('NW_SALT', Tools::passwdGen(16));
@@ -131,7 +134,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         Configuration::updateValue('NW_CONDITIONS', $conditions, true);
 
         return Db::getInstance()->execute('
-        CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'emailsubscription` (
+        CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'emailsubscription` (
             `id` int(6) NOT NULL AUTO_INCREMENT,
             `id_shop` INTEGER UNSIGNED NOT NULL DEFAULT \'1\',
             `id_shop_group` INTEGER UNSIGNED NOT NULL DEFAULT \'1\',
@@ -142,12 +145,12 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             `active` TINYINT(1) NOT NULL DEFAULT \'0\',
             `id_lang` int(10) NOT NULL DEFAULT \'0\',
             PRIMARY KEY(`id`)
-        ) ENGINE='._MYSQL_ENGINE_.' default CHARSET=utf8');
+        ) ENGINE=' . _MYSQL_ENGINE_ . ' default CHARSET=utf8');
     }
 
     public function uninstall()
     {
-        Db::getInstance()->execute('DROP TABLE IF EXISTS '._DB_PREFIX_.'emailsubscription');
+        Db::getInstance()->execute('DROP TABLE IF EXISTS ' . _DB_PREFIX_ . 'emailsubscription');
 
         return parent::uninstall();
     }
@@ -161,15 +164,18 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             return false;
         }
         $oldModule = Module::getInstanceByName(self::PS_16_EQUIVALENT_MODULE);
+
         if ($oldModule) {
             // This closure calls the parent class to prevent data to be erased
             // It allows the new module to be configured without migration
-            $parentUninstallClosure = function() {
+            $parentUninstallClosure = function () {
                 return parent::uninstall();
             };
+
             $parentUninstallClosure = $parentUninstallClosure->bindTo($oldModule, get_class($oldModule));
             $parentUninstallClosure();
         }
+
         return true;
     }
 
@@ -182,33 +188,36 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             $conditions = array();
             $languages = Language::getLanguages(false);
             foreach ($languages as $lang) {
-                if (Tools::getIsset('NW_CONDITIONS_'.$lang['id_lang'])) {
-                    $conditions[$lang['id_lang']] = Tools::getValue('NW_CONDITIONS_'.$lang['id_lang']);
+                if (Tools::getIsset('NW_CONDITIONS_' . $lang['id_lang'])) {
+                    $conditions[$lang['id_lang']] = Tools::getValue('NW_CONDITIONS_' . $lang['id_lang']);
                 }
             }
 
             Configuration::updateValue('NW_CONDITIONS', $conditions, true);
-
             $voucher = Tools::getValue('NW_VOUCHER_CODE');
+
             if ($voucher && !Validate::isDiscountName($voucher)) {
                 $this->_html .= $this->displayError($this->trans('The voucher code is invalid.', array(), 'Admin.Notifications.Error'));
             } else {
                 Configuration::updateValue('NW_VOUCHER_CODE', pSQL($voucher));
                 $this->_html .= $this->displayConfirmation($this->trans('Settings updated', array(), 'Admin.Notifications.Success'));
             }
+
         } elseif (Tools::isSubmit('subscribedmerged')) {
             $id = Tools::getValue('id');
 
             if (preg_match('/(^N)/', $id)) {
                 $id = (int) substr($id, 1);
-                $sql = 'UPDATE '._DB_PREFIX_.'emailsubscription SET active = 0 WHERE id = '.$id;
+                $sql = 'UPDATE ' . _DB_PREFIX_ . 'emailsubscription SET active = 0 WHERE id = ' . $id;
                 Db::getInstance()->execute($sql);
             } else {
                 $c = new Customer((int) $id);
                 $c->newsletter = (int) !$c->newsletter;
                 $c->update();
             }
-            Tools::redirectAdmin($this->context->link->getAdminLink('AdminModules', false).'&configure='.$this->name.'&conf=4&token='.Tools::getAdminTokenLite('AdminModules'));
+
+            Tools::redirectAdmin($this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name . '&conf=4&token=' . Tools::getAdminTokenLite('AdminModules'));
+
         } elseif (Tools::isSubmit('submitExport') && $action = Tools::getValue('action')) {
             $this->export_csv();
         } elseif (Tools::isSubmit('searchEmail')) {
@@ -227,7 +236,6 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     public function renderList()
     {
         $fields_list = array(
-
             'id' => array(
                 'title' => $this->trans('ID', array(), 'Admin.Global'),
                 'search' => false,
@@ -282,7 +290,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $helper_list->simple_header = false;
         $helper_list->identifier = 'id';
         $helper_list->table = 'merged';
-        $helper_list->currentIndex = $this->context->link->getAdminLink('AdminModules', false).'&configure='.$this->name;
+        $helper_list->currentIndex = $this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name;
         $helper_list->token = Tools::getAdminTokenLite('AdminModules');
         $helper_list->actions = array('viewCustomer');
 
@@ -294,8 +302,8 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $helper_list->listTotal = count($subscribers);
 
         /* Paginate the result */
-        $page = ($page = Tools::getValue('submitFilter'.$helper_list->table)) ? $page : 1;
-        $pagination = ($pagination = Tools::getValue($helper_list->table.'_pagination')) ? $pagination : 50;
+        $page = ($page = Tools::getValue('submitFilter' . $helper_list->table)) ? $page : 1;
+        $pagination = ($pagination = Tools::getValue($helper_list->table . '_pagination')) ? $pagination : 50;
         $subscribers = $this->paginateSubscribers($subscribers, $page, $pagination);
 
         return $helper_list->generateList($subscribers, $fields_list);
@@ -304,7 +312,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     public function displayViewCustomerLink($token = null, $id, $name = null)
     {
         $this->smarty->assign(array(
-            'href' => 'index.php?controller=AdminCustomers&id_customer='.(int) $id.'&updatecustomer&token='.Tools::getAdminTokenLite('AdminCustomers'),
+            'href' => 'index.php?controller=AdminCustomers&id_customer=' . (int) $id . '&updatecustomer&token=' . Tools::getAdminTokenLite('AdminCustomers'),
             'action' => $this->trans('View', array(), 'Admin.Actions'),
             'disable' => !((int) $id > 0),
         ));
@@ -317,7 +325,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $this->smarty->assign(array(
             'ajax' => $ajax,
             'enabled' => (bool) $value,
-            'url_enable' => $this->_helperlist->currentIndex.'&'.$this->_helperlist->identifier.'='.$id.'&'.$active.$this->_helperlist->table.($ajax ? '&action='.$active.$this->_helperlist->table.'&ajax='.(int) $ajax : '').((int) $id_category && (int) $id_product ? '&id_category='.(int) $id_category : '').'&token='.$token,
+            'url_enable' => $this->_helperlist->currentIndex . '&' . $this->_helperlist->identifier . '=' . $id . '&' . $active . $this->_helperlist->table . ($ajax ? '&action=' . $active . $this->_helperlist->table . '&ajax=' . (int) $ajax : '') . ((int) $id_category && (int) $id_product ? '&id_category=' . (int) $id_category : '') . '&token=' . $token,
         ));
 
         return $this->display(__FILE__, 'views/templates/admin/list_action_enable.tpl');
@@ -326,7 +334,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     public function displayUnsubscribeLink($token = null, $id, $name = null)
     {
         $this->smarty->assign(array(
-            'href' => $this->_helperlist->currentIndex.'&subscribedcustomer&'.$this->_helperlist->identifier.'='.$id.'&token='.$token,
+            'href' => $this->_helperlist->currentIndex . '&subscribedcustomer&' . $this->_helperlist->identifier . '=' . $id . '&token=' . $token,
             'action' => $this->trans('Unsubscribe', array(), 'Modules.Emailsubscription.Admin'),
         ));
 
@@ -346,18 +354,18 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     public function isNewsletterRegistered($customer_email)
     {
         $sql = 'SELECT `email`
-                FROM '._DB_PREFIX_.'emailsubscription
-                WHERE `email` = \''.pSQL($customer_email).'\'
-                AND id_shop = '.$this->context->shop->id;
+                FROM ' . _DB_PREFIX_ . 'emailsubscription
+                WHERE `email` = \'' . pSQL($customer_email) . '\'
+                AND id_shop = ' . $this->context->shop->id;
 
         if (Db::getInstance()->getRow($sql)) {
             return self::GUEST_REGISTERED;
         }
 
         $sql = 'SELECT `newsletter`
-                FROM '._DB_PREFIX_.'customer
-                WHERE `email` = \''.pSQL($customer_email).'\'
-                AND id_shop = '.$this->context->shop->id;
+                FROM ' . _DB_PREFIX_ . 'customer
+                WHERE `email` = \'' . pSQL($customer_email) . '\'
+                AND id_shop = ' . $this->context->shop->id;
 
         if (!$registered = Db::getInstance()->getRow($sql)) {
             return self::GUEST_NOT_REGISTERED;
@@ -374,6 +382,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
      * Register in email subscription.
      *
      * @param string|null $hookName
+     *
      * @return bool|string
      */
     public function newsletterRegistration($hookName = null)
@@ -381,8 +390,10 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         if (empty($_POST['blockHookName']) || $_POST['blockHookName'] !== $hookName) {
             return false;
         }
+
         if (empty($_POST['email']) || !Validate::isEmail($_POST['email'])) {
             return $this->error = $this->trans('Invalid email address.', array(), 'Shop.Notifications.Error');
+
         } elseif ($_POST['action'] == '1') {
             $register_status = $this->isNewsletterRegistered($_POST['email']);
 
@@ -395,7 +406,9 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             }
 
             return $this->valid = $this->trans('Unsubscription successful.', array(), 'Modules.Emailsubscription.Shop');
+
         } elseif ($_POST['action'] == '0') {
+
             $register_status = $this->isNewsletterRegistered($_POST['email']);
             if ($register_status > 0) {
                 return $this->error = $this->trans('This email address is already registered.', array(), 'Modules.Emailsubscription.Shop');
@@ -404,6 +417,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             $email = pSQL($_POST['email']);
             if (!$this->isRegistered($register_status)) {
                 if (Configuration::get('NW_VERIFICATION_EMAIL')) {
+
                     // create an unactive entry in the newsletter database
                     if ($register_status == self::GUEST_NOT_REGISTERED) {
                         $this->registerGuest($email, false);
@@ -416,6 +430,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                     $this->sendVerificationEmail($email, $token);
 
                     return $this->valid = $this->trans('A verification email has been sent. Please check your inbox.', array(), 'Modules.Emailsubscription.Shop');
+
                 } else {
                     if ($this->register($email, $register_status)) {
                         $this->valid = $this->trans('You have successfully subscribed to this newsletter.', array(), 'Modules.Emailsubscription.Shop');
@@ -442,11 +457,11 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $dbquery->from('customer', 'c');
         $dbquery->leftJoin('shop', 's', 's.id_shop = c.id_shop');
         $dbquery->leftJoin('gender', 'g', 'g.id_gender = c.id_gender');
-        $dbquery->leftJoin('gender_lang', 'gl', 'g.id_gender = gl.id_gender AND gl.id_lang = '.(int) $this->context->employee->id_lang);
+        $dbquery->leftJoin('gender_lang', 'gl', 'g.id_gender = gl.id_gender AND gl.id_lang = ' . (int) $this->context->employee->id_lang);
         $dbquery->where('c.`newsletter` = 1');
         $dbquery->leftJoin('lang', 'l', 'l.id_lang = c.id_lang');
         if ($this->_searched_email) {
-            $dbquery->where('c.`email` LIKE \'%'.pSQL($this->_searched_email).'%\' ');
+            $dbquery->where('c.`email` LIKE \'%' . pSQL($this->_searched_email) . '%\' ');
         }
 
         $customers = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($dbquery->build());
@@ -458,7 +473,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $dbquery->leftJoin('lang', 'l', 'l.id_lang = e.id_lang');
         $dbquery->where('e.`active` = 1');
         if ($this->_searched_email) {
-            $dbquery->where('e.`email` LIKE \'%'.pSQL($this->_searched_email).'%\' ');
+            $dbquery->where('e.`email` LIKE \'%' . pSQL($this->_searched_email) . '%\' ');
         }
 
         $non_customers = Db::getInstance()->executeS($dbquery->build());
@@ -497,7 +512,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
      * or update the customer table depending of the register status.
      *
      * @param string $email
-     * @param int    $register_status
+     * @param int $register_status
      */
     protected function register($email, $register_status)
     {
@@ -515,9 +530,9 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     protected function unregister($email, $register_status)
     {
         if ($register_status == self::GUEST_REGISTERED) {
-            $sql = 'DELETE FROM '._DB_PREFIX_.'emailsubscription WHERE `email` = \''.pSQL($_POST['email']).'\' AND id_shop = '.$this->context->shop->id;
+            $sql = 'DELETE FROM ' . _DB_PREFIX_ . 'emailsubscription WHERE `email` = \'' . pSQL($_POST['email']) . '\' AND id_shop = ' . $this->context->shop->id;
         } elseif ($register_status == self::CUSTOMER_REGISTERED) {
-            $sql = 'UPDATE '._DB_PREFIX_.'customer SET `newsletter` = 0 WHERE `email` = \''.pSQL($_POST['email']).'\' AND id_shop = '.$this->context->shop->id;
+            $sql = 'UPDATE ' . _DB_PREFIX_ . 'customer SET `newsletter` = 0 WHERE `email` = \'' . pSQL($_POST['email']) . '\' AND id_shop = ' . $this->context->shop->id;
         }
 
         if (!isset($sql) || !Db::getInstance()->execute($sql)) {
@@ -536,10 +551,10 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
      */
     protected function registerUser($email)
     {
-        $sql = 'UPDATE '._DB_PREFIX_.'customer
-                SET `newsletter` = 1, newsletter_date_add = NOW(), `ip_registration_newsletter` = \''.pSQL(Tools::getRemoteAddr()).'\'
-                WHERE `email` = \''.pSQL($email).'\'
-                AND id_shop = '.$this->context->shop->id;
+        $sql = 'UPDATE ' . _DB_PREFIX_ . 'customer
+                SET `newsletter` = 1, newsletter_date_add = NOW(), `ip_registration_newsletter` = \'' . pSQL(Tools::getRemoteAddr()) . '\'
+                WHERE `email` = \'' . pSQL($email) . '\'
+                AND id_shop = ' . $this->context->shop->id;
 
         return Db::getInstance()->execute($sql);
     }
@@ -548,27 +563,27 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
      * Subscribe a guest to the newsletter.
      *
      * @param string $email
-     * @param bool   $active
+     * @param bool $active
      *
      * @return bool
      */
     protected function registerGuest($email, $active = true)
     {
-        $sql = 'INSERT INTO '._DB_PREFIX_.'emailsubscription (id_shop, id_shop_group, email, newsletter_date_add, ip_registration_newsletter, http_referer, active, id_lang)
+        $sql = 'INSERT INTO ' . _DB_PREFIX_ . 'emailsubscription (id_shop, id_shop_group, email, newsletter_date_add, ip_registration_newsletter, http_referer, active, id_lang)
                 VALUES
-                ('.$this->context->shop->id.',
-                '.$this->context->shop->id_shop_group.',
-                \''.pSQL($email).'\',
+                (' . $this->context->shop->id . ',
+                ' . $this->context->shop->id_shop_group . ',
+                \'' . pSQL($email) . '\',
                 NOW(),
-                \''.pSQL(Tools::getRemoteAddr()).'\',
+                \'' . pSQL(Tools::getRemoteAddr()) . '\',
                 (
                     SELECT c.http_referer
-                    FROM '._DB_PREFIX_.'connections c
-                    WHERE c.id_guest = '.(int) $this->context->customer->id.'
+                    FROM ' . _DB_PREFIX_ . 'connections c
+                    WHERE c.id_guest = ' . (int) $this->context->customer->id . '
                     ORDER BY c.date_add DESC LIMIT 1
                 ),
-                '.(int) $active.',
-                '. $this->context->language->id . '
+                ' . (int) $active . ',
+                ' . $this->context->language->id . '
                 )';
 
         return Db::getInstance()->execute($sql);
@@ -577,9 +592,9 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     public function activateGuest($email)
     {
         return Db::getInstance()->execute(
-            'UPDATE `'._DB_PREFIX_.'emailsubscription`
+            'UPDATE `' . _DB_PREFIX_ . 'emailsubscription`
                         SET `active` = 1
-                        WHERE `email` = \''.pSQL($email).'\''
+                        WHERE `email` = \'' . pSQL($email) . '\''
         );
     }
 
@@ -593,8 +608,8 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     protected function getGuestEmailByToken($token)
     {
         $sql = 'SELECT `email`
-                FROM `'._DB_PREFIX_.'emailsubscription`
-                WHERE MD5(CONCAT( `email` , `newsletter_date_add`, \''.pSQL(Configuration::get('NW_SALT')).'\')) = \''.pSQL($token).'\'
+                FROM `' . _DB_PREFIX_ . 'emailsubscription`
+                WHERE MD5(CONCAT( `email` , `newsletter_date_add`, \'' . pSQL(Configuration::get('NW_SALT')) . '\')) = \'' . pSQL($token) . '\'
                 AND `active` = 0';
 
         return Db::getInstance()->getValue($sql);
@@ -610,8 +625,8 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     protected function getUserEmailByToken($token)
     {
         $sql = 'SELECT `email`
-                FROM `'._DB_PREFIX_.'customer`
-                WHERE MD5(CONCAT( `email` , `date_add`, \''.pSQL(Configuration::get('NW_SALT')).'\')) = \''.pSQL($token).'\'
+                FROM `' . _DB_PREFIX_ . 'customer`
+                WHERE MD5(CONCAT( `email` , `date_add`, \'' . pSQL(Configuration::get('NW_SALT')) . '\')) = \'' . pSQL($token) . '\'
                 AND `newsletter` = 0';
 
         return Db::getInstance()->getValue($sql);
@@ -626,15 +641,15 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     protected function getToken($email, $register_status)
     {
         if (in_array($register_status, array(self::GUEST_NOT_REGISTERED, self::GUEST_REGISTERED))) {
-            $sql = 'SELECT MD5(CONCAT( `email` , `newsletter_date_add`, \''.pSQL(Configuration::get('NW_SALT')).'\')) as token
-                    FROM `'._DB_PREFIX_.'emailsubscription`
+            $sql = 'SELECT MD5(CONCAT( `email` , `newsletter_date_add`, \'' . pSQL(Configuration::get('NW_SALT')) . '\')) as token
+                    FROM `' . _DB_PREFIX_ . 'emailsubscription`
                     WHERE `active` = 0
-                    AND `email` = \''.pSQL($email).'\'';
+                    AND `email` = \'' . pSQL($email) . '\'';
         } elseif ($register_status == self::CUSTOMER_NOT_REGISTERED) {
-            $sql = 'SELECT MD5(CONCAT( `email` , `date_add`, \''.pSQL(Configuration::get('NW_SALT')).'\' )) as token
-                    FROM `'._DB_PREFIX_.'customer`
+            $sql = 'SELECT MD5(CONCAT( `email` , `date_add`, \'' . pSQL(Configuration::get('NW_SALT')) . '\' )) as token
+                    FROM `' . _DB_PREFIX_ . 'customer`
                     WHERE `newsletter` = 0
-                    AND `email` = \''.pSQL($email).'\'';
+                    AND `email` = \'' . pSQL($email) . '\'';
         }
 
         return Db::getInstance()->getValue($sql);
@@ -703,6 +718,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     protected function sendVoucher($email, $code)
     {
         $language = new Language($this->context->language->id);
+
         return Mail::Send(
             $this->context->language->id,
             'newsletter_voucher',
@@ -721,7 +737,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             null,
             null,
             null,
-            dirname(__FILE__).'/mails/',
+            dirname(__FILE__) . '/mails/',
             false,
             $this->context->shop->id
         );
@@ -737,6 +753,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     protected function sendConfirmationEmail($email)
     {
         $language = new Language($this->context->language->id);
+
         return Mail::Send(
             $this->context->language->id,
             'newsletter_conf',
@@ -753,7 +770,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             null,
             null,
             null,
-            dirname(__FILE__).'/mails/',
+            dirname(__FILE__) . '/mails/',
             false,
             $this->context->shop->id
         );
@@ -794,7 +811,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             null,
             null,
             null,
-            dirname(__FILE__).'/mails/',
+            dirname(__FILE__) . '/mails/',
             false,
             $this->context->shop->id
         );
@@ -810,10 +827,10 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $this->smarty->assign($this->getWidgetVariables($hookName, $configuration));
         $this->context->smarty->assign(array(
             'id_module' => $this->id,
-            'hookName' => $hookName
+            'hookName' => $hookName,
         ));
 
-        return $this->fetch('module:ps_emailsubscription/views/templates/hook/'.$template_file);
+        return $this->fetch('module:ps_emailsubscription/views/templates/hook/' . $template_file);
     }
 
     public function getWidgetVariables($hookName = null, array $configuration = [])
@@ -826,6 +843,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         if (Tools::isSubmit('submitNewsletter')) {
             $this->error = $this->valid = '';
             $this->newsletterRegistration($hookName);
+
             if ($this->error) {
                 $variables['value'] = Tools::getValue('email', '');
                 $variables['msg'] = $this->error;
@@ -857,7 +875,8 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             if ($code = Configuration::get('NW_VOUCHER_CODE')) {
                 $this->sendVoucher($email, $code);
             }
-            return (bool) Db::getInstance()->execute('DELETE FROM '._DB_PREFIX_.'emailsubscription WHERE id_shop='.(int) $id_shop.' AND email=\''.pSQL($email)."'");
+
+            return (bool) Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'emailsubscription WHERE id_shop=' . (int) $id_shop . ' AND email=\'' . pSQL($email) . "'");
         }
 
         return true;
@@ -887,7 +906,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             (new FormField())
                 ->setName('newsletter')
                 ->setType('checkbox')
-                ->setLabel($label));
+                ->setLabel($label), );
     }
 
     public function renderForm()
@@ -964,12 +983,13 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $helper = new HelperForm();
         $helper->show_toolbar = false;
         $helper->table = $this->table;
+
         $lang = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
         $helper->default_form_language = $lang->id;
         $helper->allow_employee_form_lang = Configuration::get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG') ? Configuration::get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG') : 0;
         $helper->identifier = $this->identifier;
         $helper->submit_action = 'submitUpdate';
-        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false).'&configure='.$this->name.'&tab_module='.$this->tab.'&module_name='.$this->name;
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name;
         $helper->token = Tools::getAdminTokenLite('AdminModules');
         $helper->tpl_vars = array(
             'fields_value' => $this->getConfigFieldsValues(),
@@ -1064,13 +1084,14 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $helper = new HelperForm();
         $helper->show_toolbar = false;
         $helper->table = $this->table;
+
         $lang = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
         $helper->default_form_language = $lang->id;
         $helper->allow_employee_form_lang = Configuration::get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG') ? Configuration::get('PS_BO_ALLOW_EMPLOYEE_FORM_LANG') : 0;
         $helper->id = (int) Tools::getValue('id_carrier');
         $helper->identifier = $this->identifier;
         $helper->submit_action = 'btnSubmit';
-        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false).'&configure='.$this->name.'&tab_module='.$this->tab.'&module_name='.$this->name;
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name;
         $helper->token = Tools::getAdminTokenLite('AdminModules');
         $helper->tpl_vars = array(
             'fields_value' => $this->getConfigFieldsValues(),
@@ -1109,7 +1130,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $helper->table = $this->table;
         $helper->identifier = $this->identifier;
         $helper->submit_action = 'searchEmail';
-        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false).'&configure='.$this->name.'&tab_module='.$this->tab.'&module_name='.$this->name;
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminModules', false) . '&configure=' . $this->name . '&tab_module=' . $this->tab . '&module_name=' . $this->name;
         $helper->token = Tools::getAdminTokenLite('AdminModules');
         $helper->tpl_vars = array(
             'fields_value' => array('searched_email' => $this->_searched_email),
@@ -1126,7 +1147,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $languages = Language::getLanguages(false);
         foreach ($languages as $lang) {
             $conditions[$lang['id_lang']] = Tools::getValue(
-                'NW_CONDITIONS_'.$lang['id_lang'],
+                'NW_CONDITIONS_' . $lang['id_lang'],
                 Configuration::get('NW_CONDITIONS', $lang['id_lang']
                 )
             );
@@ -1155,26 +1176,30 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         if ($result) {
             if (!$nb = count($result)) {
                 $this->_html .= $this->displayError($this->trans('No customers found with these filters!', array(), 'Modules.Emailsubscription.Admin'));
-            } elseif ($fd = @fopen(dirname(__FILE__).'/'.strval(preg_replace('#\.{2,}#', '.', Tools::getValue('action'))).'_'.$this->file, 'w')) {
-                $header = array('id', 'shop_name', 'gender', 'lastname', 'firstname', 'email', 'subscribed', 'subscribed_on','iso_language');
+
+            } elseif ($fd = @fopen(dirname(__FILE__) . '/' . strval(preg_replace('#\.{2,}#', '.', Tools::getValue('action'))) . '_' . $this->file, 'w')) {
+                $header = array('id', 'shop_name', 'gender', 'lastname', 'firstname', 'email', 'subscribed', 'subscribed_on', 'iso_language');
                 $array_to_export = array_merge(array($header), $result);
+
                 foreach ($array_to_export as $tab) {
                     $this->myFputCsv($fd, $tab);
                 }
+
                 fclose($fd);
+
                 $this->_html .= $this->displayConfirmation(
-                    sprintf($this->trans('The .CSV file has been successfully exported: %d customers found.', array(), 'Modules.Emailsubscription.Admin'), $nb).'<br />
-                <a href="'.$this->context->shop->getBaseURI().'modules/ps_emailsubscription/'.Tools::safeOutput(strval(Tools::getValue('action'))).'_'.$this->file.'">
-                <b>'.$this->trans('Download the file', array(), 'Modules.Emailsubscription.Admin').' '.$this->file.'</b>
+                    sprintf($this->trans('The .CSV file has been successfully exported: %d customers found.', array(), 'Modules.Emailsubscription.Admin'), $nb) . '<br />
+                <a href="' . $this->context->shop->getBaseURI() . 'modules/ps_emailsubscription/' . Tools::safeOutput(strval(Tools::getValue('action'))) . '_' . $this->file . '">
+                <b>' . $this->trans('Download the file', array(), 'Modules.Emailsubscription.Admin') . ' ' . $this->file . '</b>
                 </a>
                 <br />
                 <ol style="margin-top: 10px;">
-                    <li style="color: red;">'.
-                    $this->trans('WARNING: When opening this .csv file with Excel, choose UTF-8 encoding to avoid strange characters.', array(), 'Modules.Emailsubscription.Admin').
+                    <li style="color: red;">' .
+                    $this->trans('WARNING: When opening this .csv file with Excel, choose UTF-8 encoding to avoid strange characters.', array(), 'Modules.Emailsubscription.Admin') .
                     '</li>
                 </ol>');
             } else {
-                $this->_html .= $this->displayError($this->trans('Error: Write access limited', array(), 'Modules.Emailsubscription.Admin').' '.dirname(__FILE__).'/'.strval(Tools::getValue('action')).'_'.$this->file.' !');
+                $this->_html .= $this->displayError($this->trans('Error: Write access limited', array(), 'Modules.Emailsubscription.Admin') . ' ' . dirname(__FILE__) . '/' . strval(Tools::getValue('action')) . '_' . $this->file . ' !');
             }
         } else {
             $this->_html .= $this->displayError($this->trans('No result found!', array(), 'Modules.Emailsubscription.Admin'));
@@ -1227,21 +1252,21 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             $dbquery->from('customer', 'c');
             $dbquery->leftJoin('shop', 's', 's.id_shop = c.id_shop');
             $dbquery->leftJoin('gender', 'g', 'g.id_gender = c.id_gender');
-            $dbquery->leftJoin('gender_lang', 'gl', 'g.id_gender = gl.id_gender AND gl.id_lang = '.$this->context->employee->id_lang);
-            $dbquery->where('c.`newsletter` = '.($who == 3 ? 0 : 1));
+            $dbquery->leftJoin('gender_lang', 'gl', 'g.id_gender = gl.id_gender AND gl.id_lang = ' . $this->context->employee->id_lang);
+            $dbquery->where('c.`newsletter` = ' . ($who == 3 ? 0 : 1));
             $dbquery->leftJoin('lang', 'l', 'l.id_lang = c.id_lang');
             if ($optin == 2 || $optin == 1) {
-                $dbquery->where('c.`optin` = '.($optin == 1 ? 0 : 1));
+                $dbquery->where('c.`optin` = ' . ($optin == 1 ? 0 : 1));
             }
             if ($country) {
                 $dbquery->where('(SELECT COUNT(a.`id_address`) as nb_country
-                                                    FROM `'._DB_PREFIX_.'address` a
+                                                    FROM `' . _DB_PREFIX_ . 'address` a
                                                     WHERE a.deleted = 0
                                                     AND a.`id_customer` = c.`id_customer`
-                                                    AND a.`id_country` = '.$country.') >= 1');
+                                                    AND a.`id_country` = ' . $country . ') >= 1');
             }
             if ($id_shop) {
-                $dbquery->where('c.`id_shop` = '.$id_shop);
+                $dbquery->where('c.`id_shop` = ' . $id_shop);
             }
 
             $customers = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($dbquery->build());
@@ -1256,7 +1281,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             $dbquery->where('e.`active` = 1');
             $dbquery->leftJoin('lang', 'l', 'l.id_lang = e.id_lang');
             if ($id_shop) {
-                $dbquery->where('e.`id_shop` = '.$id_shop);
+                $dbquery->where('e.`id_shop` = ' . $id_shop);
             }
             $non_customers = Db::getInstance()->executeS($dbquery->build());
         }
@@ -1271,7 +1296,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $line = implode(';', $array);
         $line .= "\n";
         if (!fwrite($fd, $line, 4096)) {
-            $this->post_errors[] = $this->trans('Error: Write access limited', array(), 'Modules.Emailsubscription.Admin').' '.dirname(__FILE__).'/'.$this->file.' !';
+            $this->post_errors[] = $this->trans('Error: Write access limited', array(), 'Modules.Emailsubscription.Admin') . ' ' . dirname(__FILE__) . '/' . $this->file . ' !';
         }
     }
 
@@ -1286,13 +1311,14 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
 
     /**
      * This hook allow you to add new fields in the admin customer form
+     *
      * @return string
      */
     public function hookDisplayAdminCustomersForm()
     {
         $newsletter = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue('SELECT `newsletter`
             FROM ' . _DB_PREFIX_ . 'customer
-            WHERE `id_customer` = ' . (int)Tools::getValue('id_customer', 0));
+            WHERE `id_customer` = ' . (int) Tools::getValue('id_customer', 0));
 
         $input = array(
             'type' => 'switch',
@@ -1312,7 +1338,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                     'id' => 'newsletter_off',
                     'value' => 0,
                     'label' => $this->trans('Disabled', array(), 'Admin.Global'),
-                )
+                ),
             ),
             'hint' => $this->trans('This customer will receive your newsletter via email.', array(), 'Admin.Orderscustomers.Help'),
         );
@@ -1324,21 +1350,24 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     public function hookActionDeleteGDPRCustomer($customer)
     {
         if (!empty($customer['email']) && Validate::isEmail($customer['email'])) {
-            $sql = "DELETE FROM "._DB_PREFIX_."emailsubscription WHERE email = '".pSQL($customer['email'])."'";
+            $sql = 'DELETE FROM ' . _DB_PREFIX_ . "emailsubscription WHERE email = '" . pSQL($customer['email']) . "'";
             if (Db::getInstance()->execute($sql)) {
                 return json_encode(true);
             }
+
             return json_encode($this->trans('Newsletter subscription: no email to delete, this customer has not registered.', array(), 'Modules.Emailsubscription.Admin'));
         }
     }
+
     public function hookActionExportGDPRData($customer)
     {
         if (!Tools::isEmpty($customer['email']) && Validate::isEmail($customer['email'])) {
-            $sql = "SELECT * FROM "._DB_PREFIX_."emailsubscription WHERE email = '".pSQL($customer['email'])."'";
+            $sql = 'SELECT * FROM ' . _DB_PREFIX_ . "emailsubscription WHERE email = '" . pSQL($customer['email']) . "'";
             if ($res = Db::getInstance()->ExecuteS($sql)) {
                 return json_encode($res);
             }
+
             return json_encode($this->trans('Newsletter subscription: no email to export, this customer has not registered.', array(), 'Modules.Emailsubscription.Admin'));
-       }
-   }
+        }
+    }
 }

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -387,8 +387,12 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
      */
     public function newsletterRegistration($hookName = null)
     {
-        if (empty($_POST['blockHookName']) || $_POST['blockHookName'] !== $hookName) {
-            return false;
+        $isPrestaShopVersionOver177 = version_compare(_PS_VERSION_, '1.7.7', '>=');
+
+        if ($isPrestaShopVersionOver177) {
+            if (empty($_POST['blockHookName']) || $_POST['blockHookName'] !== $hookName) {
+                return false;
+            }
         }
 
         if (empty($_POST['email']) || !Validate::isEmail($_POST['email'])) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | dev
| Description?  | Only activate the blockHookName validation for PS versions > 1.7.7. This ensures that this v2.5 of the module is compatible with PS < 1.7.7
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/15425
| How to test?  | Please see ticket