### PR TITLE
Fix issue where html tags from ps_emailsubscription module would be escaped and not interpreted as HTML

### DIFF
--- a/views/templates/front/subscription_execution.tpl
+++ b/views/templates/front/subscription_execution.tpl
@@ -33,7 +33,7 @@
   </p>
 
   {if $variables.conditions}
-    <p>{$variables.conditions}</p>
+    <p>{$variables.conditions nofilter}</p>
   {/if}
 
 {/block}

--- a/views/templates/hook/ps_emailsubscription-column.tpl
+++ b/views/templates/hook/ps_emailsubscription-column.tpl
@@ -31,7 +31,7 @@
   <form action="{$urls.current_url}#blockEmailSubscription_{$hookName}" method="post">
     <input type="text" name="email" value="{$value}" placeholder="{l s='Your e-mail' d='Modules.Emailsubscription.Shop'}" />
     {if $conditions}
-      <p>{$conditions}</p>
+      <p>{$conditions nofilter}</p>
     {/if}
     <input type="hidden" name="blockHookName" value="{$hookName}" />
     <input type="submit" name="submitNewsletter" value="ok" />

--- a/views/templates/hook/ps_emailsubscription.tpl
+++ b/views/templates/hook/ps_emailsubscription.tpl
@@ -31,7 +31,7 @@
   <form action="{$urls.current_url}#blockEmailSubscription_{$hookName}" method="post">
     <input type="text" name="email" value="{$value}" placeholder="{l s='Your e-mail' d='Modules.Emailsubscription.Shop'}" />
     {if $conditions}
-      <p>{$conditions}</p>
+      <p>{$conditions nofilter}</p>
     {/if}
     <input type="hidden" value="{$hookName}" name="blockHookName" />
     <input type="submit" value="ok" name="submitNewsletter" />


### PR DESCRIPTION
<!--
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
 -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | HTML elements in the conditions field of emailsubscription module were not interpreted in FO
| Type?         | bug fix
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #15849
| How to test?  | Just put an html element in the conditions field of emailsubscription module and see if it render correctly in your account -> personal information/identity in FO

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/16468)
<!-- Reviewable:end -->
