### PR TITLE
Add an hook for newsletter registration/unregistration

### DIFF
--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -408,7 +408,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                 'hookError' => &$hookError,
             ]
         );
-        if ($hookError) {
+        if ($hookError !== null) {
             return $this->error = $hookError;
         }
 

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -400,7 +400,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         // hook for newsletter registration/unregistration : fill-in hookError string is there is an error
         $hookError = null;
         Hook::exec(
-            'actionNewsletterRegistration', 
+            'actionNewsletterRegistrationBefore', 
             [
                 'hookName' => $hookName, 
                 'email' => $_POST['email'], 

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -469,6 +469,16 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                 }
             }
         }
+        // hook 
+        Hook::exec(
+            'actionNewsletterRegistrationAfter', 
+            [
+                'hookName' => $hookName, 
+                'email' => $_POST['email'], 
+                'action' => $_POST['action'], 
+                'error' => $this->error,
+            ]
+        );
     }
 
     public function getSubscribers()

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -398,7 +398,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         }
 
         // hook for newsletter registration/unregistration : fill-in hookError string is there is an error
-        $hookError = '';
+        $hookError = null;
         Hook::exec('actionNewsletterRegistration', ['hookName' => $hookName, 'email' => $_POST['email'], 'action' => $_POST['action'], 'hookError' => &$hookError]);
         if ($hookError) {
             return $this->error = $hookError;

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -397,6 +397,12 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             }
         }
 
+        // hook for newsletter registration/unregistration : fill-in hookError string is there is an error
+        $hookError = '';
+        Hook::exec('actionNewsletterRegistration', ['hookName' => $hookName, 'email' => $_POST['email'], 'action' => $_POST['action'], 'hookError' => &$hookError]);
+        if ($hookError) {
+            return $this->error = $hookError;
+        }
 
         if (empty($_POST['email']) || !Validate::isEmail($_POST['email'])) {
             return $this->error = $this->trans('Invalid email address.', array(), 'Shop.Notifications.Error');

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -476,7 +476,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                 'hookName' => $hookName, 
                 'email' => $_POST['email'], 
                 'action' => $_POST['action'], 
-                'error' => $this->error,
+                'error' => &$this->error,
             ]
         );
     }

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -399,7 +399,15 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
 
         // hook for newsletter registration/unregistration : fill-in hookError string is there is an error
         $hookError = null;
-        Hook::exec('actionNewsletterRegistration', ['hookName' => $hookName, 'email' => $_POST['email'], 'action' => $_POST['action'], 'hookError' => &$hookError]);
+        Hook::exec(
+            'actionNewsletterRegistration', 
+            [
+                'hookName' => $hookName, 
+                'email' => $_POST['email'], 
+                'action' => $_POST['action'], 
+                'hookError' => &$hookError,
+            ]
+        );
         if ($hookError) {
             return $this->error = $hookError;
         }

--- a/views/templates/hook/ps_emailsubscription-column.tpl
+++ b/views/templates/hook/ps_emailsubscription-column.tpl
@@ -33,6 +33,7 @@
     {if $conditions}
       <p>{$conditions nofilter}</p>
     {/if}
+    {hook h='displayNewsletterRegistration'}
     <input type="hidden" name="blockHookName" value="{$hookName}" />
     <input type="submit" name="submitNewsletter" value="ok" />
     {hook h='displayGDPRConsent' id_module=$id_module}

--- a/views/templates/hook/ps_emailsubscription.tpl
+++ b/views/templates/hook/ps_emailsubscription.tpl
@@ -33,6 +33,7 @@
     {if $conditions}
       <p>{$conditions nofilter}</p>
     {/if}
+    {hook h='displayNewsletterRegistration'}
     <input type="hidden" value="{$hookName}" name="blockHookName" />
     <input type="submit" value="ok" name="submitNewsletter" />
     {hook h='displayGDPRConsent' id_module=$id_module}


### PR DESCRIPTION
I've added two hooks :
- actionNewsletterRegistration that can return an error in hookError arg
- displayNewsletterRegistration for the tpl. This hook has to be added to hook/ps_emailsubscription.tpl of classic theme.

Fixes https://github.com/PrestaShop/PrestaShop/issues/17075