### PR TITLE
Do not send voucher when customer signs up if he did not register for newsletter 

### DIFF
--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -876,7 +876,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $id_shop = $params['newCustomer']->id_shop;
         $email = $params['newCustomer']->email;
         if (Validate::isEmail($email)) {
-            if ($code = Configuration::get('NW_VOUCHER_CODE')) {
+            if ($params['newCustomer']->newsletter && $code = Configuration::get('NW_VOUCHER_CODE')) {
                 $this->sendVoucher($email, $code);
             }
 


### PR DESCRIPTION
When signin up, the customer receives a voucher all the time, even if he did not register for the newsletter, this bug was introduced in this PR: https://github.com/PrestaShop/ps_emailsubscription/pull/38

Fixes https://github.com/PrestaShop/PrestaShop/issues/17990