### PR TITLE
Set email input basic browser validation again

### DIFF
--- a/views/templates/hook/ps_emailsubscription.tpl
+++ b/views/templates/hook/ps_emailsubscription.tpl
@@ -29,7 +29,7 @@
     <p class="notification {if $nw_error}notification-error{else}notification-success{/if}">{$msg}</p>
   {/if}
   <form action="{$urls.current_url}#blockEmailSubscription_{$hookName}" method="post">
-    <input type="text" name="email" value="{$value}" placeholder="{l s='Your e-mail' d='Modules.Emailsubscription.Shop'}" />
+    <input type="email" name="email" value="{$value}" placeholder="{l s='Your e-mail' d='Modules.Emailsubscription.Shop'}" required />
     {if $conditions}
       <p>{$conditions nofilter}</p>
     {/if}


### PR DESCRIPTION
Removed on this commit, probably a mistake when merging: 
https://github.com/PrestaShop/ps_emailsubscription/commit/3038ea2a16e618422c0f58450a07b51d2e8773b5#diff-379ede661ac5ff63283a80bc5010fcd3

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Set email input basic browser validation again, Removed on some commit, probably a mistake when merging
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
