### PR TITLE
Add unsubscribe page

### DIFF
--- a/controllers/front/unsubscription.php
+++ b/controllers/front/unsubscription.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * 2007-2020 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+/**
+ * @since 1.5.0
+ */
+class Ps_EmailsubscriptionUnsubscriptionModuleFrontController extends ModuleFrontController
+{
+    private $variables = [];
+
+    /**
+     * @see FrontController::postProcess()
+     */
+    public function postProcess()
+    {
+        $this->variables['value'] = Tools::getValue('email', '');
+        $this->variables['msg'] = '';
+        $this->variables['conditions'] = Configuration::get('NW_CONDITIONS', $this->context->language->id);
+
+        if (Tools::isSubmit('submitNewsletter') || $this->ajax) {
+            $this->module->newsletterRegistration();
+            if ($this->module->error) {
+                $this->variables['msg'] = $this->module->error;
+                $this->variables['nw_error'] = true;
+            } elseif ($this->module->valid) {
+                $this->variables['msg'] = $this->module->valid;
+                $this->variables['nw_error'] = false;
+            }
+
+            if ($this->ajax) {
+                header('Content-Type: application/json');
+                $this->ajaxDie(json_encode($this->variables));
+            }
+        }
+    }
+
+    /**
+     * @see FrontController::initContent()
+     */
+    public function initContent()
+    {
+        parent::initContent();
+
+        $this->context->smarty->assign('variables', $this->variables);
+        $this->setTemplate('module:ps_emailsubscription/views/templates/front/unsubscription_execution.tpl');
+    }
+}

--- a/views/templates/front/unsubscription_execution.tpl
+++ b/views/templates/front/unsubscription_execution.tpl
@@ -3,15 +3,13 @@
 {block name="page_content"}
   <h1>{l s='Newsletter Unsubscription' d='Modules.Emailsubscription.Shop'}</h1>
 
-<div class="email_subscription block_newsletter_unsubscribe" id="blockEmailSubscription_unsubscribe">
+<div class="email_subscription block_newsletter" id="blockEmailSubscription_unsubscribe">
   {if $variables.msg}
     <p class="notification {if $variables.nw_error}notification-error{else}notification-success{/if}">{$variables.msg}</p>
   {/if}
   <form action="{$urls.current_url}" method="post">
     <input type="text" name="email" value="{$variables.value}" placeholder="{l s='Your e-mail' d='Modules.Emailsubscription.Shop'}" />
-    {if $variables.conditions}
-      <p>{$variables.conditions nofilter}</p>
-    {/if}
+    <p>{l s='Please enter your email to unsubscribe from our newsletter.' d='Modules.Emailsubscription.Shop'}</p>
     {hook h='displayNewsletterRegistration'}
     <input type="hidden" value="blockEmailSubscription_unsubscribe" name="blockHookName" />
     <input type="submit" value="ok" name="submitNewsletter" />

--- a/views/templates/front/unsubscription_execution.tpl
+++ b/views/templates/front/unsubscription_execution.tpl
@@ -1,0 +1,22 @@
+{extends file='page.tpl'}
+
+{block name="page_content"}
+  <h1>{l s='Newsletter Unsubscription' d='Modules.Emailsubscription.Shop'}</h1>
+
+<div class="email_subscription block_newsletter_unsubscribe" id="blockEmailSubscription_unsubscribe">
+  {if $variables.msg}
+    <p class="notification {if $variables.nw_error}notification-error{else}notification-success{/if}">{$variables.msg}</p>
+  {/if}
+  <form action="{$urls.current_url}" method="post">
+    <input type="text" name="email" value="{$variables.value}" placeholder="{l s='Your e-mail' d='Modules.Emailsubscription.Shop'}" />
+    {if $variables.conditions}
+      <p>{$variables.conditions nofilter}</p>
+    {/if}
+    {hook h='displayNewsletterRegistration'}
+    <input type="hidden" value="blockEmailSubscription_unsubscribe" name="blockHookName" />
+    <input type="submit" value="ok" name="submitNewsletter" />
+    <input type="hidden" name="action" value="1" />
+  </form>
+</div>
+
+{/block}

--- a/views/templates/front/unsubscription_execution.tpl
+++ b/views/templates/front/unsubscription_execution.tpl
@@ -3,18 +3,19 @@
 {block name="page_content"}
   <h1>{l s='Newsletter Unsubscription' d='Modules.Emailsubscription.Shop'}</h1>
 
-<div class="email_subscription block_newsletter" id="blockEmailSubscription_unsubscribe">
-  {if $variables.msg}
-    <p class="notification {if $variables.nw_error}notification-error{else}notification-success{/if}">{$variables.msg}</p>
-  {/if}
-  <form action="{$urls.current_url}" method="post">
-    <input type="text" name="email" value="{$variables.value}" placeholder="{l s='Your e-mail' d='Modules.Emailsubscription.Shop'}" />
-    <p>{l s='Please enter your email to unsubscribe from our newsletter.' d='Modules.Emailsubscription.Shop'}</p>
-    {hook h='displayNewsletterRegistration'}
-    <input type="hidden" value="blockEmailSubscription_unsubscribe" name="blockHookName" />
-    <input type="submit" value="ok" name="submitNewsletter" />
-    <input type="hidden" name="action" value="1" />
-  </form>
-</div>
+  <div class="email_subscription block_newsletter" id="blockEmailSubscription_unsubscribe">
+    {if $variables.msg}
+      <p class="notification {if $variables.nw_error}notification-error{else}notification-success{/if}{$variables.msg}</p>
+    {/if}
+
+    <form action="{$urls.current_url}" method="post">
+      <input type="text" name="email" value="{$variables.value}" placeholder="{l s='Your e-mail' d='Modules.Emailsubscription.Shop'}" />
+      <p>{l s='Please enter your email to unsubscribe from our newsletter.' d='Modules.Emailsubscription.Shop'}</p>
+      {hook h='displayNewsletterRegistration'}
+      <input type="hidden" value="blockEmailSubscription_unsubscribe" name="blockHookName" />
+      <input type="submit" value="ok" name="submitNewsletter" />
+      <input type="hidden" name="action" value="1" />
+    </form>
+  </div>
 
 {/block}

--- a/views/templates/front/unsubscription_execution.tpl
+++ b/views/templates/front/unsubscription_execution.tpl
@@ -17,5 +17,4 @@
       <input type="hidden" name="action" value="1" />
     </form>
   </div>
-
 {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Introduces a new front controller for unsubscribing from the newsletter using an email address. Users can currently subscribe but cannot unsubscribe unless they have an account and login to change their preferences.
| Type?         |  new feature 
| BC breaks?    |  no
| Deprecations? |  no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#21860
| How to test?  | Install module and navigate to [Domain]/module/ps_emailsubscription/unsubscription  ![unsubscribe](https://user-images.githubusercontent.com/54888056/127890869-ef7a609a-5594-4a3d-b3fa-783cee5dfadb.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
