### PR TITLE
"if (Validate::isEmail($email))" it's always true

### DIFF
--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -919,20 +919,17 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $id_shop = $params['newCustomer']->id_shop;
         $email = $params['newCustomer']->email;
         $newsletter = $params['newCustomer']->newsletter;
-        if (Validate::isEmail($email)) {
-            if ($params['newCustomer']->newsletter && $code = Configuration::get('NW_VOUCHER_CODE')) {
-                $this->sendVoucher($email, $code);
-            }
 
+        if ($this->isNewsletterRegistered($email) == self::GUEST_REGISTERED) {
             return (bool) Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'emailsubscription WHERE id_shop=' . (int) $id_shop . ' AND email=\'' . pSQL($email) . "'");
         }
 
         if ($newsletter) {
             if (Configuration::get('NW_CONFIRMATION_EMAIL')) {// send confirmation email
-                $this->sendConfirmationEmail($params['newCustomer']->email);
+                $this->sendConfirmationEmail($email);
             }
             if ($code = Configuration::get('NW_VOUCHER_CODE')) {// send voucher
-                $this->sendVoucher($params['newCustomer']->email, $code);
+                $this->sendVoucher($email, $code);
             }
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | "if (Validate::isEmail($email))" it's always true, since the $email is already validated at the creation moment of the customer, so the script won't be able to achieve the rest of cases.
| Type?         | bugfix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | Make sure that everything is ok with subscription during account creation

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
