### PR TITLE
Fix php8 compatibility

### DIFF
--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -341,7 +341,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         return $helper_list->generateList($subscribers, $fields_list);
     }
 
-    public function displayViewCustomerLink($token = null, $id, $name = null)
+    public function displayViewCustomerLink($token = null, $id = null, $name = null)
     {
         $this->smarty->assign([
             'href' => 'index.php?controller=AdminCustomers&id_customer=' . (int) $id . '&updatecustomer&token=' . Tools::getAdminTokenLite('AdminCustomers'),
@@ -363,7 +363,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         return $this->display(__FILE__, 'views/templates/admin/list_action_enable.tpl');
     }
 
-    public function displayUnsubscribeLink($token = null, $id, $name = null)
+    public function displayUnsubscribeLink($token = null, $id = null, $name = null)
     {
         $this->smarty->assign([
             'href' => $this->_helperlist->currentIndex . '&subscribedcustomer&' . $this->_helperlist->identifier . '=' . $id . '&token=' . $token,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | function arguments that come after an optional one should be optional as well in order to be compatible with PHP 8.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | No test need AFAIK

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
