### PR TITLE
Add newsletter registration hook to email verification handler

### DIFF
--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -750,6 +750,16 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             $this->sendConfirmationEmail($email);
         }
 
+        Hook::exec(
+            'actionNewsletterRegistrationAfter',
+            [
+                'hookName' => null,
+                'email' => $email,
+                'action' => '0',
+                'error' => &$this->error,
+            ]
+        );
+
         return $this->trans('Thank you for subscribing to our newsletter.', [], 'Modules.Emailsubscription.Shop');
     }
 

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -758,7 +758,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             [
                 'hookName' => null,
                 'email' => $email,
-                'action' => self::NEWSLETTER_SUBSCRIPTION,
+                'action' => static::NEWSLETTER_SUBSCRIPTION,
                 'error' => &$this->error,
             ]
         );

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -441,6 +441,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                 'email' => $_POST['email'],
                 'action' => $_POST['action'],
                 'hookError' => &$hookError,
+                'module' => $this->name,
             ]
         );
         /** @var string|null $hookError */
@@ -508,6 +509,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                 'email' => $_POST['email'],
                 'action' => $_POST['action'],
                 'error' => &$this->error,
+                'module' => $this->name,
             ]
         );
 
@@ -760,6 +762,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                 'email' => $email,
                 'action' => static::NEWSLETTER_SUBSCRIPTION,
                 'error' => &$this->error,
+                'module' => $this->name,
             ]
         );
 

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -41,8 +41,8 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     const GUEST_REGISTERED = 1;
     const CUSTOMER_REGISTERED = 2;
 
-    public const NEWSLETTER_SUBSCRIPTION = 0;
-    public const NEWSLETTER_UNSUBSCRIPTION = 1;
+    const NEWSLETTER_SUBSCRIPTION = 0;
+    const NEWSLETTER_UNSUBSCRIPTION = 1;
 
     const LEGAL_PRIVACY = 'LEGAL_PRIVACY';
 

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -462,7 +462,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             }
 
             return $this->valid = $this->trans('Unsubscription successful.', [], 'Modules.Emailsubscription.Shop');
-        } elseif ($_POST['action'] == self::NEWSLETTER_SUBSCRIPTION) {
+        } elseif ($_POST['action'] == static::NEWSLETTER_SUBSCRIPTION) {
             $register_status = $this->isNewsletterRegistered($_POST['email']);
             if ($register_status > 0) {
                 return $this->error = $this->trans('This email address is already registered.', [], 'Modules.Emailsubscription.Shop');

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -41,6 +41,9 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     const GUEST_REGISTERED = 1;
     const CUSTOMER_REGISTERED = 2;
 
+    public const NEWSLETTER_SUBSCRIPTION = 0;
+    public const NEWSLETTER_UNSUBSCRIPTION = 1;
+
     const LEGAL_PRIVACY = 'LEGAL_PRIVACY';
 
     protected $_origin_newsletter;
@@ -447,7 +450,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
 
         if (empty($_POST['email']) || !Validate::isEmail($_POST['email'])) {
             return $this->error = $this->trans('Invalid email address.', [], 'Shop.Notifications.Error');
-        } elseif ($_POST['action'] == '1') {
+        } elseif ($_POST['action'] == self::NEWSLETTER_UNSUBSCRIPTION) {
             $register_status = $this->isNewsletterRegistered($_POST['email']);
 
             if ($register_status < 1) {
@@ -459,7 +462,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             }
 
             return $this->valid = $this->trans('Unsubscription successful.', [], 'Modules.Emailsubscription.Shop');
-        } elseif ($_POST['action'] == '0') {
+        } elseif ($_POST['action'] == self::NEWSLETTER_SUBSCRIPTION) {
             $register_status = $this->isNewsletterRegistered($_POST['email']);
             if ($register_status > 0) {
                 return $this->error = $this->trans('This email address is already registered.', [], 'Modules.Emailsubscription.Shop');
@@ -755,7 +758,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             [
                 'hookName' => null,
                 'email' => $email,
-                'action' => '0',
+                'action' => self::NEWSLETTER_SUBSCRIPTION,
                 'error' => &$this->error,
             ]
         );

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -450,7 +450,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
 
         if (empty($_POST['email']) || !Validate::isEmail($_POST['email'])) {
             return $this->error = $this->trans('Invalid email address.', [], 'Shop.Notifications.Error');
-        } elseif ($_POST['action'] == self::NEWSLETTER_UNSUBSCRIPTION) {
+        } elseif ($_POST['action'] == static::NEWSLETTER_UNSUBSCRIPTION) {
             $register_status = $this->isNewsletterRegistered($_POST['email']);
 
             if ($register_status < 1) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Currently the only way the newsletter registration hook (actionNewsletterRegistrationAfter) fires is when the module setting "Would you like to send a verification email after subscription?" is disabled. Add the hook to the email verification handler function, so it also fires when the setting is enabled and a customer verifies their registration.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | Use [this test module](https://github.com/PrestaShop/ps_emailsubscription/files/7343826/newslettertest.zip). It logs to the PrestaShop log when the hook fires.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! --
>
