### PR TITLE
Allow guests to re-subscribe after unsubscribing them from the module configuration

### DIFF
--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -228,7 +228,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
 
             if (preg_match('/(^N)/', $id)) {
                 $id = (int) Tools::substr($id, 1);
-                $sql = 'UPDATE ' . _DB_PREFIX_ . 'emailsubscription SET active = 0 WHERE id = ' . $id;
+                $sql = 'DELETE FROM ' . _DB_PREFIX_ . 'emailsubscription WHERE id = ' . $id;
                 Db::getInstance()->execute($sql);
             } else {
                 $c = new Customer((int) $id);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When you unsubscribe a visitor subscribed to the newsletter via the "subscriber" checkbox in the module configuration listing (see screenshot), the "active" field changes to false in the DB. This prevents the visitor from re-subscribing to the newsletter. If the visitor unsubscribes himself, the line is deleted in the DB and he can re-subscribe.
| Type?         | bug fix / improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | none
| How to test?  | <ul><li>Subscribe to the newsletter as a guest</li><li>Un-subscribe yourself from the newsletter in the module configuration</li><li>Re-subscribe to the newsletter as a guest with the same email</li></ul> |

![image](https://user-images.githubusercontent.com/36694523/222738678-e41ba976-49b9-4c84-9198-b21f443ef38b.png)

