### PR TITLE
Fix voucher code if it starts with non zero characters

### DIFF
--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -475,7 +475,8 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                         return $this->error = $this->trans('An error occurred during the subscription process.', [], 'Modules.Emailsubscription.Shop');
                     }
 
-                    if ($code = Configuration::get('NW_VOUCHER_CODE')) {
+                    $code = Configuration::get('NW_VOUCHER_CODE');
+                    if (!empty($code)) {
                         $this->sendVoucher($email, $code);
                     }
 
@@ -963,7 +964,8 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             if (Configuration::get('NW_CONFIRMATION_EMAIL')) {// send confirmation email
                 $this->sendConfirmationEmail($params['newCustomer']->email);
             }
-            if ($code = Configuration::get('NW_VOUCHER_CODE')) {// send voucher
+            $code = Configuration::get('NW_VOUCHER_CODE');
+            if (!empty($code)) {
                 $this->sendVoucher($params['newCustomer']->email, $code);
             }
         }
@@ -985,7 +987,8 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         if (Configuration::get('NW_CONFIRMATION_EMAIL')) {// send confirmation email
             $this->sendConfirmationEmail($params['customer']->email);
         }
-        if ($code = Configuration::get('NW_VOUCHER_CODE')) {
+        $code = Configuration::get('NW_VOUCHER_CODE');
+        if (!empty($code)) {
             $cartRule = CartRuleCore::getCartsRuleByCode($code, Context::getContext()->language->id);
             if (!Order::getDiscountsCustomer($params['customer']->id, $cartRule[0])) {// send voucher
                 $this->sendVoucher($params['customer']->email, $code);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The original code works only if voucher code starts with non zero characters. When voucher code starts with letters, the wrong template is used.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Use a voucher code like "HELLO" and you will receive the confirmation template, use a voucher code like "1HELLO" and you'll receive the voucher template