### PR TITLE
Add default data into configuration

### DIFF
--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -153,6 +153,9 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             $conditions[(int) $lang['id_lang']] = $this->getConditionFixtures($lang);
         }
         Configuration::updateValue('NW_CONDITIONS', $conditions, true);
+        Configuration::updateValue('NW_VERIFICATION_EMAIL', false);
+        Configuration::updateValue('NW_CONFIRMATION_EMAIL', false);
+        Configuration::updateValue('NW_VOUCHER_CODE', '');
 
         return Db::getInstance()->execute('
         CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'emailsubscription` (


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Adds default configuration values for the form data. Prevents issues like https://github.com/PrestaShop/PrestaShop/issues/35004 in older PS versions.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#35004
| How to test?  | Install this module on clean 8.1.x and check that the switch has a "No" value.

