### PR TITLE
Properly cast bool values

### DIFF
--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -206,8 +206,8 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     public function getContent()
     {
         if (Tools::isSubmit('submitUpdate')) {
-            Configuration::updateValue('NW_CONFIRMATION_EMAIL', (bool) Tools::getValue('NW_CONFIRMATION_EMAIL'));
-            Configuration::updateValue('NW_VERIFICATION_EMAIL', (bool) Tools::getValue('NW_VERIFICATION_EMAIL'));
+            Configuration::updateValue('NW_CONFIRMATION_EMAIL', (int) Tools::getValue('NW_CONFIRMATION_EMAIL'));
+            Configuration::updateValue('NW_VERIFICATION_EMAIL', (int) Tools::getValue('NW_VERIFICATION_EMAIL'));
 
             $conditions = [];
             $languages = Language::getLanguages(false);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Properly casts bool values when saving to database. When you pass false, it will save it as null, resulting in empty switches. I checked all other modules and this is the only one where there was this typo.
| Type?         | 
| BC breaks?    | 
| Deprecations? | 
| Fixed ticket? | 
| How to test?  | 