### PR TITLE
Better GDPR data export

### DIFF
--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -1465,8 +1465,9 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     public function hookActionExportGDPRData($customer)
     {
         if (!Tools::isEmpty($customer['email']) && Validate::isEmail($customer['email'])) {
-            $sql = 'SELECT * FROM ' . _DB_PREFIX_ . "emailsubscription WHERE email = '" . pSQL($customer['email']) . "'";
-            if ($res = Db::getInstance()->executeS($sql)) {
+            $this->_searched_email = $customer['email'];
+
+            if ($res = $this->getSubscribers()) {
                 return json_encode($res);
             }
 


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | There are two places where we retrieve the subscriber list, but the code inside `hookActionExportGDPRData` is too basic and doesn't handle all cases. As a result, we get inconsistent data — on the subscribers page in the BO, we see that a user has subscribed to the newsletter, but when downloading personal information via the psgdpr module (which uses `hookActionExportGDPRData`), some data are missing. It's also problematic to have two blocks of code doing the same thing.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | none
| How to test?  | Change the newsletter setting on the customer page in the BO, and then download the personal data using the psgdpr module. With the old code, it will not retrieve any results related to the newsletter, even though the module's BO page shows the user as a subscriber.
