### PR TITLE
Fix: BO ps_emailsubscription not multistore compliant

### DIFF
--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -505,6 +505,11 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
 
     public function getSubscribers()
     {
+        $shopIds = [];
+        if (Shop::isFeatureActive()) {
+            $shopIds = Shop::getContextListShopID();
+        }
+
         $dbquery = new DbQuery();
         $dbquery->select('c.`id_customer` AS `id`, s.`name` AS `shop_name`, gl.`name` AS `gender`, c.`lastname`, c.`firstname`, c.`email`, c.`newsletter` AS `subscribed`, c.`newsletter_date_add`, l.`iso_code`');
         $dbquery->from('customer', 'c');
@@ -517,6 +522,10 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             $dbquery->where('c.`email` LIKE \'%' . pSQL($this->_searched_email) . '%\' ');
         }
 
+        if (!empty($shopIds)) {
+            $dbquery->where('c.`id_shop` IN (' . implode(',', $shopIds) . ')');
+        }
+
         $customers = Db::getInstance((bool) _PS_USE_SQL_SLAVE_)->executeS($dbquery->build());
 
         $dbquery = new DbQuery();
@@ -527,6 +536,10 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $dbquery->where('e.`active` = 1');
         if ($this->_searched_email) {
             $dbquery->where('e.`email` LIKE \'%' . pSQL($this->_searched_email) . '%\' ');
+        }
+
+        if (!empty($shopIds)) {
+            $dbquery->where('e.`id_shop` IN (' . implode(',', $shopIds) . ')');
         }
 
         $non_customers = Db::getInstance()->executeS($dbquery->build());


### PR DESCRIPTION
Filter newsletter subscribers by selected shop context in module configuration

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR updates the `getSubscribers()` method to filter newsletter subscribers (both customers and non-customers) according to the current multishop context defined in the module configuration.<br/>If the multishop feature is active, only subscribers belonging to the current shop or shop group are displayed.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? |  no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#36152
| How to test?  | 1. Enable the **Multishop** feature and create a second shop. <br/>2. Add newsletter emails in both shops — using the newsletter module and customer registration form. <br/> 3. Open the module configuration page and check that the subscriber list changes according to the selected shop context.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
