### PR TITLE
Refactor hookActionCustomerAccountAdd in ps_emailsubscription

### DIFF
--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -977,7 +977,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                 $this->sendVoucher($email, $code);
             }
 
-            return (bool) Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'emailsubscription WHERE id_shop=' . (int) $id_shop . ' AND email=\'' . pSQL($email) . "'");
+            return Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'emailsubscription` WHERE id_shop = ' . (int) $id_shop . 'AND email = "' . pSQL($email) . '"');
         }
 
         return true;

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -977,7 +977,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                 $this->sendVoucher($email, $code);
             }
 
-            return Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'emailsubscription` WHERE id_shop = ' . (int) $id_shop . 'AND email = "' . pSQL($email) . '"');
+            return Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'emailsubscription` WHERE id_shop = ' . (int) $id_shop . ' AND email = "' . pSQL($email) . '"');
         }
 
         return true;

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -964,25 +964,20 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         if (empty($params['newCustomer'])) {
             return false;
         }
+
         $id_shop = $params['newCustomer']->id_shop;
         $email = $params['newCustomer']->email;
-        $newsletter = $params['newCustomer']->newsletter;
-        if (Validate::isEmail($email)) {
-            if ($params['newCustomer']->newsletter && $code = Configuration::get('NW_VOUCHER_CODE')) {
-                $this->sendVoucher($email, $code);
-            }
-            if ($params['newCustomer']->newsletter) {
-                return (bool) Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'emailsubscription WHERE id_shop=' . (int) $id_shop . ' AND email=\'' . pSQL($email) . "'");
-            }
+
+        if (!Validate::isEmail($email)) {
+            return false;
         }
 
-        if ($newsletter) {
-            if (Configuration::get('NW_CONFIRMATION_EMAIL')) {// send confirmation email
-                $this->sendConfirmationEmail($params['newCustomer']->email);
+        if ($params['newCustomer']->newsletter) {
+            if ($code = Configuration::get('NW_VOUCHER_CODE')) {
+                $this->sendVoucher($email, $code);
             }
-            if ($code = Configuration::get('NW_VOUCHER_CODE')) {// send voucher
-                $this->sendVoucher($params['newCustomer']->email, $code);
-            }
+
+            return (bool) Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'emailsubscription WHERE id_shop=' . (int) $id_shop . ' AND email=\'' . pSQL($email) . "'");
         }
 
         return true;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR simplifies the `hookActionCustomerAccountAdd` logic by acting only on valid emails and newsletter-subscribed customers, removing unnecessary and unreachable code.<br/><br/>**Related**: https://github.com/PrestaShop/ps_emailsubscription/pull/114#issuecomment-3621286680
| Type?         | refacto 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
