### PR TITLE
Fix: SQL queries using NOW() rely on MySQL timezone instead of shop timezone

### DIFF
--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -618,7 +618,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     protected function registerUser($email)
     {
         $sql = 'UPDATE ' . _DB_PREFIX_ . 'customer
-                SET `newsletter` = 1, newsletter_date_add = NOW(), `ip_registration_newsletter` = \'' . pSQL(Tools::getRemoteAddr()) . '\'
+                SET `newsletter` = 1, newsletter_date_add = \'' . date('Y-m-d H:i:s') . '\', `ip_registration_newsletter` = \'' . pSQL(Tools::getRemoteAddr()) . '\'
                 WHERE `email` = \'' . pSQL($email) . '\'
                 AND id_shop = ' . $this->context->shop->id;
 
@@ -640,7 +640,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
                 (' . $this->context->shop->id . ',
                 ' . $this->context->shop->id_shop_group . ',
                 \'' . pSQL($email) . '\',
-                NOW(),
+                \'' . date('Y-m-d H:i:s') . '\',
                 \'' . pSQL(Tools::getRemoteAddr()) . '\',
                 (
                     SELECT c.http_referer


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | dev
| Description?      | \`registerUser()\` and \`registerGuest()\` used \`NOW()\` to store the newsletter subscription date (\`newsletter_date_add\`), which relies on the MySQL server timezone (UTC by default). Replaced with PHP's \`date('Y-m-d H:i:s')\` so the shop's configured timezone is used.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed issue or discussion?     | Related to PrestaShop/PrestaShop#30828
| Related PRs       | PrestaShop/PrestaShop#41596
| Sponsor company   | PrestaShop SA