### PR TITLE
CI: align PHPStan on PS 8.2+ and fix PS 9.x controller-typing errors

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -87,8 +87,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        presta_version: ['9.0.3', '9.1.x', 'develop']
-        php_version: ['8.1', '8.5']
+        include:
+          # PrestaShop 9.0.x supports PHP 8.1 up to 8.4 (8.5 is not supported)
+          - { presta_version: '9.0.3', php_version: '8.1' }
+          - { presta_version: '9.0.3', php_version: '8.4' }
+          # PrestaShop 9.1.x and develop support PHP 8.1 up to 8.5
+          - { presta_version: '9.1.x', php_version: '8.1' }
+          - { presta_version: '9.1.x', php_version: '8.5' }
+          - { presta_version: 'develop', php_version: '8.1' }
+          - { presta_version: 'develop', php_version: '8.5' }
       fail-fast: false
     env:
       PHPRC: ${{ github.workspace }}/${{ github.event.repository.name }}/.phpstan-php-ini
@@ -98,7 +105,7 @@ jobs:
         with:
           path: ${{ github.event.repository.name }}
 
-      - name: Prepare PHP env for PrestaShop 9.1.x and later (define constants before any bootstrap)
+      - name: Prepare PHP env for PrestaShop ${{ matrix.presta_version }} (define constants before any bootstrap)
         run: |
           mkdir -p ${{ github.event.repository.name }}/.phpstan-php-ini
           {

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,11 +11,26 @@ jobs:
       - name: PHP syntax checker 7.2
         uses: prestashop/github-action-php-lint/7.2@master
 
+      - name: PHP syntax checker 7.3
+        uses: prestashop/github-action-php-lint/7.3@master
+
       - name: PHP syntax checker 7.4
         uses: prestashop/github-action-php-lint/7.4@master
 
       - name: PHP syntax checker 8.0
         uses: prestashop/github-action-php-lint/8.0@master
+
+      - name: PHP syntax checker 8.1
+        uses: prestashop/github-action-php-lint/8.1@master
+
+      - name: PHP syntax checker 8.2
+        uses: prestashop/github-action-php-lint/8.2@master
+
+      - name: PHP syntax checker 8.3
+        uses: prestashop/github-action-php-lint/8.3@master
+
+      - name: PHP syntax checker 8.4
+        uses: prestashop/github-action-php-lint/8.4@master
 
       - name: PHP syntax checker 8.5
         uses: prestashop/github-action-php-lint/8.5@master
@@ -30,14 +45,14 @@ jobs:
         with:
           php-version: '7.4'
 
-  # Run PHPStan against the module (PHP 7.4 – 8.1)
+  # Run PHPStan against the module (PHP 7.2 – 8.1)
   phpstan-74:
-    name: PHPStan (PHP 7.4 - 8.1)
+    name: PHPStan (PHP 7.2 - 8.1)
     runs-on: ubuntu-latest
     strategy:
       matrix:
         presta_version: ['8.2.x']
-        php_version: ['7.4', '8.1']
+        php_version: ['7.2', '8.1']
       fail-fast: false
     env:
       PHPRC: ${{ github.workspace }}/${{ github.event.repository.name }}/.phpstan-php-ini
@@ -72,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        presta_version: ['9.1.x', 'develop']
+        presta_version: ['9.0.3', '9.1.x', 'develop']
         php_version: ['8.1', '8.5']
       fail-fast: false
     env:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        presta_version: ['8.1.7', '8.2.x']
+        presta_version: ['8.2.x']
         php_version: ['7.4', '8.1']
       fail-fast: false
     env:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -66,40 +66,6 @@ jobs:
           phpstan-version: '^0.12'
           composer-version: '2.2.18'
 
-  # Run PHPStan against the module (PHP 8.1 – 8.4)
-  phpstan-80-84:
-    name: PHPStan (PHP 8.1 - 8.4 )
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        presta_version: ['9.0.x']
-        php_version: ['8.1', '8.4']
-      fail-fast: false
-    env:
-      PHPRC: ${{ github.workspace }}/${{ github.event.repository.name }}/.phpstan-php-ini
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          path: ${{ github.event.repository.name }}
-
-      - name: Prepare PHP env for PrestaShop 9.0.x (define constants before any bootstrap)
-        run: |
-          mkdir -p ${{ github.event.repository.name }}/.phpstan-php-ini
-          {
-            echo "auto_prepend_file=$GITHUB_WORKSPACE/${{ github.event.repository.name }}/tests/php/phpstan/prepend-constants.php"
-            echo "memory_limit=512M"
-          } > ${{ github.event.repository.name }}/.phpstan-php-ini/php.ini
-
-      - name: Run PHPStan
-        uses: Prestashop/.github/.github/actions/php-ci/phpstan@master
-        with:
-          php-version: ${{ matrix.php_version }}
-          presta-version: ${{ matrix.presta_version }}
-          module-name: ${{ github.event.repository.name }}
-          phpstan-level: '5'
-          phpstan-config: tests/php/phpstan/phpstan-${{ matrix.presta_version }}.neon
-
   # Run PHPStan against the module (PHP 8.1 – 8.5)
   phpstan:
     name: PHPStan (PHP 8.1 - 8.5)

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_emailsubscription</name>
     <displayName><![CDATA[E-mail subscription form]]></displayName>
-    <version><![CDATA[2.8.3]]></version>
+    <version><![CDATA[3.0.0]]></version>
     <description><![CDATA[Adds a block for newsletter subscription.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <confirmUninstall><![CDATA[Are you sure that you want to delete all of your contacts?]]></confirmUninstall>

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -100,7 +100,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $this->confirmUninstall = $this->trans('Are you sure that you want to delete all of your contacts?', [], 'Modules.Emailsubscription.Admin');
         $this->ps_versions_compliancy = ['min' => '8.2.0', 'max' => _PS_VERSION_];
 
-        $this->version = '2.8.3';
+        $this->version = '3.0.0';
         $this->author = 'PrestaShop';
         $this->error = false;
         $this->valid = false;

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -411,9 +411,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
      */
     public function newsletterRegistration($hookName = null)
     {
-        $isPrestaShopVersionOver177 = version_compare(_PS_VERSION_, '1.7.7', '>=');
-
-        if ($isPrestaShopVersionOver177 && ($hookName !== null)) {
+        if ($hookName !== null) {
             if (empty($_POST['blockHookName']) || $_POST['blockHookName'] !== $hookName) {
                 return false;
             }

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -98,7 +98,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $this->displayName = $this->trans('Newsletter subscription', [], 'Modules.Emailsubscription.Admin');
         $this->description = $this->trans('Keep in touch with your customers the way you want, add a form to the homepage of your store and allow all the curious to subscribe to your newsletter.', [], 'Modules.Emailsubscription.Admin');
         $this->confirmUninstall = $this->trans('Are you sure that you want to delete all of your contacts?', [], 'Modules.Emailsubscription.Admin');
-        $this->ps_versions_compliancy = ['min' => '8.1.0', 'max' => _PS_VERSION_];
+        $this->ps_versions_compliancy = ['min' => '8.2.0', 'max' => _PS_VERSION_];
 
         $this->version = '2.8.3';
         $this->author = 'PrestaShop';

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -945,7 +945,24 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             'psemailsubscription_subscription' => $this->context->link->getModuleLink($this->name, 'subscription', [], true),
         ]);
 
-        $this->context->controller->registerJavascript('modules-psemailsubscription', 'modules/' . $this->name . '/views/js/ps_emailsubscription.js');
+        /** @var FrontController $controller */
+        $controller = $this->context->controller;
+        $controller->registerJavascript('modules-psemailsubscription', 'modules/' . $this->name . '/views/js/ps_emailsubscription.js');
+    }
+
+    /**
+     * Returns the admin controller with a concrete type. Context::$controller is typed
+     * as the PHPStan-opaque LegacyControllerContext on PrestaShop 9.x, which prevents
+     * static resolution of legacy controller methods such as getLanguages().
+     *
+     * @return AdminController
+     */
+    private function getAdminController()
+    {
+        /** @var AdminController $controller */
+        $controller = $this->context->controller;
+
+        return $controller;
     }
 
     /**
@@ -1124,7 +1141,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $helper->token = Tools::getAdminTokenLite('AdminModules');
         $helper->tpl_vars = [
             'fields_value' => $this->getConfigFieldsValues(),
-            'languages' => $this->context->controller->getLanguages(),
+            'languages' => $this->getAdminController()->getLanguages(),
             'id_language' => $this->context->language->id,
         ];
 
@@ -1225,7 +1242,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $helper->token = Tools::getAdminTokenLite('AdminModules');
         $helper->tpl_vars = [
             'fields_value' => $this->getConfigFieldsValues(),
-            'languages' => $this->context->controller->getLanguages(),
+            'languages' => $this->getAdminController()->getLanguages(),
             'id_language' => $this->context->language->id,
         ];
 
@@ -1264,7 +1281,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
         $helper->token = Tools::getAdminTokenLite('AdminModules');
         $helper->tpl_vars = [
             'fields_value' => ['searched_email' => $this->_searched_email],
-            'languages' => $this->context->controller->getLanguages(),
+            'languages' => $this->getAdminController()->getLanguages(),
             'id_language' => $this->context->language->id,
         ];
 

--- a/tests/php/phpstan/phpstan-8.1.7.neon
+++ b/tests/php/phpstan/phpstan-8.1.7.neon
@@ -1,5 +1,0 @@
-includes:
-	- %currentWorkingDirectory%/tests/php/phpstan/phpstan.neon
-
-parameters:
-  ignoreErrors:

--- a/tests/php/phpstan/phpstan-8.2.x.neon
+++ b/tests/php/phpstan/phpstan-8.2.x.neon
@@ -1,5 +1,2 @@
 includes:
 	- %currentWorkingDirectory%/tests/php/phpstan/phpstan.neon
-
-parameters:
-  ignoreErrors:

--- a/tests/php/phpstan/phpstan-9.0.3.neon
+++ b/tests/php/phpstan/phpstan-9.0.3.neon
@@ -1,0 +1,2 @@
+includes:
+	- %currentWorkingDirectory%/tests/php/phpstan/phpstan.neon

--- a/tests/php/phpstan/phpstan-9.0.x.neon
+++ b/tests/php/phpstan/phpstan-9.0.x.neon
@@ -1,7 +1,0 @@
-includes:
-	- %currentWorkingDirectory%/tests/php/phpstan/phpstan.neon
-
-parameters:
-  ignoreErrors:
-    - '#Call to method registerJavascript\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Call to method getLanguages\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'

--- a/tests/php/phpstan/phpstan-9.1.x.neon
+++ b/tests/php/phpstan/phpstan-9.1.x.neon
@@ -1,7 +1,2 @@
 includes:
 	- %currentWorkingDirectory%/tests/php/phpstan/phpstan.neon
-
-parameters:
-  ignoreErrors:
-    - '#Call to method registerJavascript\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Call to method getLanguages\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'

--- a/tests/php/phpstan/phpstan-develop.neon
+++ b/tests/php/phpstan/phpstan-develop.neon
@@ -1,7 +1,2 @@
 includes:
 	- %currentWorkingDirectory%/tests/php/phpstan/phpstan.neon
-
-parameters:
-  ignoreErrors:
-    - '#Call to method registerJavascript\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'
-    - '#Call to method getLanguages\(\) on an unknown class PrestaShop\\PrestaShop\\Core\\Context\\LegacyControllerContext\.#'


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | dev
| Description?      | The `phpstan-80-84` CI job targeted PrestaShop `9.0.x` which no longer exists as a branch, causing systematic PHPStan failures. Rather than dropping PS 9.0 coverage, this PR moves it into the main `phpstan` job using the `9.0.3` tag instead of the removed branch.<br/><br/>This PR also aligns the module on the PS 8.2+ baseline targeted by the cleanup Epic:<br/>- drops the `8.1.7` PHPStan target (the PHP 7.2/8.1 job now runs `8.2.x` only)<br/>- replaces the dead `phpstan-9.0.x.neon` (branch) with `phpstan-9.0.3.neon` (tag) and removes the orphaned `phpstan-8.1.7.neon`<br/>- the `phpstan` job now targets `9.0.3`, `9.1.x` and `develop` (PHP 8.1–8.5, with `9.0.3` capped at PHP 8.4 since PS 9.0.x does not support 8.5)<br/>- lowers the `phpstan-74` job floor to PHP 7.2 (the real minimum for PS 8.2.x) and expands `php-linter` to check every PHP version from 7.2 to 8.5<br/>- bumps `ps_versions_compliancy` min to `8.2.0`<br/>- removes a dead version check: `version_compare(_PS_VERSION_, '1.7.7', '>=')` is always true on PS 8.2+, so the conditional in `newsletterRegistration()` is simplified<br/>- resolves the remaining PHPStan errors directly instead of suppressing them: on PS 9.x `Context::$controller` is typed as the PHPStan-opaque `LegacyControllerContext`, so `registerJavascript()` and `getLanguages()` are now called through concrete `@var`-typed controllers (`FrontController` / a new `getAdminController()` helper). All `ignoreErrors` blocks are now removed.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed issue or discussion?     | Part of PrestaShop/PrestaShop#41648
| Sponsor company   | PrestaShop SA