### PR TITLE
Avoid PHP 8 warnings on newsletter submissions without an action

### DIFF
--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -417,6 +417,12 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             }
         }
 
+        // Read the action through Tools::getValue() so a submission without it (bots, partial
+        // forms) does not raise "Undefined array key" warnings on PHP 8. A missing action keeps
+        // its previous meaning: it does not match the unsubscription value and is treated as a
+        // subscription, like before.
+        $action = Tools::getValue('action');
+
         // hook for newsletter registration/unregistration : fill-in hookError string is there is an error
         $hookError = null;
         Hook::exec(
@@ -424,7 +430,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             [
                 'hookName' => $hookName,
                 'email' => $_POST['email'],
-                'action' => $_POST['action'],
+                'action' => $action,
                 'hookError' => &$hookError,
                 'module' => $this->name,
             ]
@@ -436,7 +442,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
 
         if (empty($_POST['email']) || !Validate::isEmail($_POST['email'])) {
             return $this->error = $this->trans('Invalid email address.', [], 'Shop.Notifications.Error');
-        } elseif ($_POST['action'] == static::NEWSLETTER_UNSUBSCRIPTION) {
+        } elseif ($action == static::NEWSLETTER_UNSUBSCRIPTION) {
             $register_status = $this->isNewsletterRegistered($_POST['email']);
 
             if ($register_status < 1) {
@@ -448,7 +454,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             }
 
             return $this->valid = $this->trans('Unsubscription successful.', [], 'Modules.Emailsubscription.Shop');
-        } elseif ($_POST['action'] == static::NEWSLETTER_SUBSCRIPTION) {
+        } elseif ($action == static::NEWSLETTER_SUBSCRIPTION) {
             $register_status = $this->isNewsletterRegistered($_POST['email']);
             if ($register_status > 0) {
                 return $this->error = $this->trans('This email address is already registered.', [], 'Modules.Emailsubscription.Shop');
@@ -492,7 +498,7 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             [
                 'hookName' => $hookName,
                 'email' => $_POST['email'],
-                'action' => $_POST['action'],
+                'action' => $action,
                 'error' => &$this->error,
                 'module' => $this->name,
             ]

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -417,10 +417,6 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
             }
         }
 
-        // Read the action through Tools::getValue() so a submission without it (bots, partial
-        // forms) does not raise "Undefined array key" warnings on PHP 8. A missing action keeps
-        // its previous meaning: it does not match the unsubscription value and is treated as a
-        // subscription, like before.
         $action = Tools::getValue('action');
 
         // hook for newsletter registration/unregistration : fill-in hookError string is there is an error


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | `Ps_Emailsubscription::newsletterRegistration()` read `$_POST['action']` in four places without checking it exists (the Before/After hook payloads and the two subscribe/unsubscribe branches). A POST carrying `submitNewsletter` and a valid email but **no** `action` field — common from bots and partial/misconfigured form posts — therefore raised `Undefined array key "action"` warnings on PHP 8 on every such request. The fix reads the value once with `Tools::getValue('action')` and reuses it. Behaviour is unchanged: a missing action does not equal the unsubscription value and is handled as a subscription, exactly as before (`Tools::getValue()` returns `false`, and `false == self::NEWSLETTER_SUBSCRIPTION (0)`).
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/ps_emailsubscription#125.
| How to test?  | On PHP 8.1+, POST a newsletter submission without an `action` field (`curl -X POST -d 'submitNewsletter=1&email=test@example.com' https://<shop>/`) and check the PHP error log. Before: four `Undefined array key "action"` warnings; after: none. Verified by invoking `newsletterRegistration()` with `submitNewsletter` + a valid email and no `action`: 4 warnings before, 0 after, and the email is still subscribed (behaviour preserved).
| Sponsor company   |

Root cause reported by @seederp2p.
