### PR TITLE
Don't render empty markup in the newsletter checkbox label

### DIFF
--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -1038,16 +1038,19 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
      */
     public function hookAdditionalCustomerFormFields($params)
     {
+        $conditions = Configuration::get('NW_CONDITIONS', $this->context->language->id);
+        // Only render the line break and emphasis markup when there is some conditions text;
+        // otherwise the label ends with an empty "<br><em></em>" (the placeholders collapse to
+        // an empty string and the label is simply "Sign up for our newsletter").
+        $hasConditions = !empty($conditions);
         $label = $this->trans(
             'Sign up for our newsletter[1][2]%conditions%[/2]',
             [
                 '_raw' => true,
-                '[1]' => '<br>',
-                '[2]' => '<em>',
-                '%conditions%' => Tools::htmlentitiesUTF8(
-                    Configuration::get('NW_CONDITIONS', $this->context->language->id)
-                ),
-                '[/2]' => '</em>',
+                '[1]' => $hasConditions ? '<br>' : '',
+                '[2]' => $hasConditions ? '<em>' : '',
+                '%conditions%' => $hasConditions ? Tools::htmlentitiesUTF8($conditions) : '',
+                '[/2]' => $hasConditions ? '</em>' : '',
             ],
             'Modules.Emailsubscription.Shop'
         );

--- a/ps_emailsubscription.php
+++ b/ps_emailsubscription.php
@@ -1039,9 +1039,6 @@ class Ps_Emailsubscription extends Module implements WidgetInterface
     public function hookAdditionalCustomerFormFields($params)
     {
         $conditions = Configuration::get('NW_CONDITIONS', $this->context->language->id);
-        // Only render the line break and emphasis markup when there is some conditions text;
-        // otherwise the label ends with an empty "<br><em></em>" (the placeholders collapse to
-        // an empty string and the label is simply "Sign up for our newsletter").
         $hasConditions = !empty($conditions);
         $label = $this->trans(
             'Sign up for our newsletter[1][2]%conditions%[/2]',


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | `hookAdditionalCustomerFormFields()` builds the newsletter checkbox label by always wrapping the newsletter conditions in `<br>` + `<em>…</em>`. When the "Newsletter conditions" setting (`NW_CONDITIONS`) is empty for the language, the label ends with a stray `Sign up for our newsletter<br><em></em>`, adding an empty line and emphasis element under the checkbox. The fix only emits the `<br>`/`<em>` markup when there is actually some conditions text; otherwise the placeholders collapse and the label is simply "Sign up for our newsletter". The same translation key is kept, so no new wording is introduced.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/ps_emailsubscription#130.
| How to test?  | Modules → Newsletter subscription → Configure, clear the "Newsletter conditions" field for the active language and save, then open the registration form / guest checkout newsletter checkbox and inspect the label markup. Before: `Sign up for our newsletter<br><em></em>`. After: `Sign up for our newsletter`. With conditions text configured the label is unchanged (`Sign up for our newsletter<br><em>…</em>`) — verified both cases.
| Sponsor company   |

Reported by @darkf3d3.
